### PR TITLE
Add cache expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ The following environment variables are either needed, or read if present:
 * KUBECTL_BEARER_TOKEN: identifies the ServiceAccount the app will authenticate
   against in kubernetes for kubectl calls
 * KUBECTL_CONTEXT: which kubectl context it will look for secrets in
+* SERVICE_TOKEN_CACHE_TTL: expire service token cache entries after this many
+  seconds

--- a/app/services/adapters/file_cache_adapter.rb
+++ b/app/services/adapters/file_cache_adapter.rb
@@ -7,7 +7,7 @@ class Adapters::FileCacheAdapter
   def self.put(key, value)
     create_cache_dir_if_needed!
     File.open(file_path(key), 'w') do |f|
-      f << value + "\n"
+      f << value
     end
   end
 

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -16,7 +16,7 @@ class Adapters::KubectlAdapter
       secret_name,
       '-o',
       'json'
-    ] + kubectl_args
+    ] + [kubectl_args]
   end
 
   private
@@ -24,11 +24,12 @@ class Adapters::KubectlAdapter
   def self.kubectl_args(  context: ENV['KUBECTL_CONTEXT'],
                           bearer_token: ENV['KUBECTL_BEARER_TOKEN'],
                           namespace: ENV['KUBECTL_NAMESPACE'])
-    [
-        '--context=' + context,
-        '--namespace=' + namespace,
-        '--token=' + bearer_token
-    ]
+    args = []
+    args << '--context=' + context unless context.blank?
+    args << '--namespace=' + namespace unless namespace.blank?
+    args << '--token=' + bearer_token  unless bearer_token.blank?
+
+    args.compact.join(' ')
   end
 
   def self.kubectl_binary

--- a/app/value_objects/cache_entry.rb
+++ b/app/value_objects/cache_entry.rb
@@ -1,0 +1,37 @@
+class CacheEntry
+  attr_accessor :data, :expire_after
+
+  def initialize(args={})
+    @data = args[:data] || args['data']
+    @expire_after = args[:expire_after] || args['expire_after'] || default_expire_after
+  end
+
+  def default_expire_after(ttl = ENV['SERVICE_TOKEN_CACHE_TTL'])
+    CacheEntry.current_time + ttl.to_i.seconds
+  end
+
+  def expired?
+    @expire_after < CacheEntry.current_time
+  end
+
+  # allows easy stubbing in tests
+  def self.current_time
+    Time.current.utc
+  end
+
+
+  def self.serialize(data)
+    # TTL is handled by the CacheEntry itself
+    CacheEntry.new(
+      data: data
+    ).to_json
+  end
+
+  def self.deserialize(json)
+    CacheEntry.new(
+      JSON.parse(
+        json
+      )
+    )
+  end
+end

--- a/spec/services/adapters/file_cache_adapter_spec.rb
+++ b/spec/services/adapters/file_cache_adapter_spec.rb
@@ -47,8 +47,8 @@ describe Adapters::FileCacheAdapter do
       described_class.put('key', value)
     end
 
-    it 'overwrites the file_path with the given value plus a terminating new line' do
-      expect(mock_file).to receive(:<<).with(value + "\n")
+    it 'overwrites the file_path with the given value' do
+      expect(mock_file).to receive(:<<).with(value)
       described_class.put('key', value)
     end
   end

--- a/spec/services/adapters/kubectl_adapter_spec.rb
+++ b/spec/services/adapters/kubectl_adapter_spec.rb
@@ -49,4 +49,65 @@ describe Adapters::KubectlAdapter do
       described_class.get_secret(secret_name)
     end
   end
+
+  describe '.kubectl_args' do
+    let(:context) {}
+    let(:namespace) {}
+    let(:bearer_token) {}
+    let(:args) {
+      {
+        context: context,
+        namespace: namespace,
+        bearer_token: bearer_token
+      }
+    }
+    let(:return_value) { described_class.kubectl_args(args) }
+
+    it 'returns a string' do
+      expect(return_value).to be_a(String)
+    end
+
+    context 'given no values' do
+      it 'returns an empty string' do
+        expect(return_value).to be_empty
+      end
+    end
+
+    context 'given a context' do
+      let(:context) { 'my-context' }
+
+      it 'includes --context=(context)' do
+        expect(return_value).to include('--context=my-context')
+      end
+
+      context 'and a namespace' do
+        let(:namespace) { 'my-namespace' }
+
+        it 'includes --namespace=(namespace)' do
+          expect(return_value).to include('--namespace=my-namespace')
+        end
+        it 'includes --context=(context)' do
+          expect(return_value).to include('--context=my-context')
+        end
+      end
+    end
+
+    context 'given a namespace' do
+      let(:namespace) { 'my-namespace' }
+
+      it 'includes --namespace=(namespace)' do
+        expect(return_value).to include('--namespace=my-namespace')
+      end
+    end
+
+    context 'given a bearer_token' do
+      let(:bearer_token) { 'my-bearer_token' }
+
+      it 'includes --token=(bearer_token)' do
+        expect(return_value).to include('--token=my-bearer_token')
+      end
+    end
+
+
+  end
 end

--- a/spec/value_objects/cache_entry_spec.rb
+++ b/spec/value_objects/cache_entry_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+describe CacheEntry do
+  let(:now) { Time.current.utc }
+  before do
+    allow(described_class).to receive(:current_time).and_return(now)
+  end
+
+
+  describe 'a new entry' do
+    let(:new_entry) { described_class.new(data: data, expire_after: expire_after) }
+    let(:data) { }
+    let(:expire_after) { }
+
+    context 'given :data' do
+      let(:data) { 'data' }
+      it 'stores the :data' do
+        expect(new_entry.data).to eq('data')
+      end
+    end
+    context 'given no :data' do
+      it 'has nil in the data attribute' do
+        expect(new_entry.data).to be_nil
+      end
+    end
+    context 'given :expire_after' do
+      let(:expire_after) { 'expire_after' }
+      it 'stores the :expire_after' do
+        expect(new_entry.expire_after).to eq('expire_after')
+      end
+    end
+    context 'given no :expire_after' do
+      it 'uses the default_expire_after' do
+        expect(new_entry.expire_after).to eq(new_entry.default_expire_after)
+      end
+    end
+  end
+
+  describe '#default_expire_after' do
+    context 'given a ttl' do
+      let(:ttl) { 55 }
+      it 'is the current time plus the given ttl' do
+        expect(subject.default_expire_after(ttl)).to eq(now + 55.seconds)
+      end
+    end
+    context 'given no ttl' do
+      before do
+        allow(ENV).to receive(:[]).with('SERVICE_TOKEN_CACHE_TTL').and_return("17")
+      end
+      it 'uses the SERVICE_TOKEN_CACHE_TTL environment variable' do
+        expect(subject.default_expire_after).to eq(now + 17.seconds)
+      end
+    end
+  end
+
+  describe '#expired?' do
+    context 'when expire_after is less than the current time' do
+      before do
+        subject.expire_after = now - 1.second
+      end
+      it 'returns true' do
+        expect(subject.expired?).to eq(true)
+      end
+    end
+    context 'when expire_after is more than the current time' do
+      before do
+        subject.expire_after = now + 1.second
+      end
+      it 'returns true' do
+        expect(subject.expired?).to eq(false)
+      end
+    end
+  end
+
+  describe '.serialize' do
+    it 'returns a string' do
+      expect(described_class.serialize('my data')).to be_a(String)
+    end
+
+    describe 'the returned string' do
+      let(:returned_string) { described_class.serialize('my data') }
+
+      context 'when parsed as JSON' do
+        let(:returned_string_parsed_as_json) { JSON.parse(returned_string) }
+        it 'is valid' do
+          expect{ JSON.parse(returned_string) }.to_not raise_error
+        end
+
+        it 'has the given data' do
+          expect(returned_string_parsed_as_json['data']).to eq('my data')
+        end
+      end
+    end
+  end
+
+  describe '.deserialize' do
+
+    context 'given valid JSON' do
+      let(:json) { '{"data": "69ba765b88c9d0a52a1379328b5ae09f", "expire_after": "2018-09-25T11:46:11.844Z"}' }
+
+      it 'returns a CacheEntry' do
+        expect(described_class.deserialize(json)).to be_a(CacheEntry)
+      end
+
+      describe 'the returned CacheEntry' do
+        let(:returned_cache_entry) { described_class.deserialize(json) }
+        it 'has the data from the JSON' do
+          expect(returned_cache_entry.data).to eq('69ba765b88c9d0a52a1379328b5ae09f')
+        end
+        it 'has the expire_after from the JSON' do
+          expect(returned_cache_entry.expire_after).to eq('2018-09-25T11:46:11.844Z')
+        end
+
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Introduce auto-expiry to cache keys, driven by the SERVICE_TOKEN_CACHE_TTL environment variable