### PR TITLE
Support kubectl & Elasticache for Redis cache 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::API
   private
 
   def enforce_json_only
+    Rails.logger.debug "request.format = #{request.format}, json? = #{request.format.json?}"
     response.status = :unacceptable unless request.format.json?
   end
 

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -23,7 +23,7 @@ class Adapters::KubectlAdapter
 
   def self.kubectl_args(  context: ENV['KUBECTL_CONTEXT'],
                           bearer_token: ENV['KUBECTL_BEARER_TOKEN'],
-                          namespace: ENV['KUBECTL_NAMESPACE'])
+                          namespace: ENV['KUBECTL_SERVICES_NAMESPACE'])
     args = []
     args << '--context=' + context unless context.blank?
     args << '--namespace=' + namespace unless namespace.blank?

--- a/config/initializers/service_token_cache.rb
+++ b/config/initializers/service_token_cache.rb
@@ -3,9 +3,7 @@ service_token_cache_class = Adapters::FileCacheAdapter
 if url.present?
   begin
     uri_with_protocol = (ENV['REDIS_PROTOCOL'] || 'redis://') + url
-    puts "uri_with_protocol = #{uri_with_protocol}"
     uri = URI.parse(uri_with_protocol)
-    puts uri.inspect
     Rails.configuration.x.service_token_cache_redis = Redis.new(
       url: uri_with_protocol,
       password: ENV['REDIS_AUTH_TOKEN']

--- a/config/initializers/service_token_cache.rb
+++ b/config/initializers/service_token_cache.rb
@@ -2,8 +2,14 @@ url = ENV["REDISCLOUD_URL"] || ENV['REDIS_URL']
 service_token_cache_class = Adapters::FileCacheAdapter
 if url.present?
   begin
-    uri = URI.parse(url)
-    Rails.configuration.x.service_token_cache_redis = Redis.new(host:uri.host, port:uri.port, password:uri.password)
+    uri_with_protocol = (ENV['REDIS_PROTOCOL'] || 'redis://') + url
+    puts "uri_with_protocol = #{uri_with_protocol}"
+    uri = URI.parse(uri_with_protocol)
+    puts uri.inspect
+    Rails.configuration.x.service_token_cache_redis = Redis.new(
+      url: uri_with_protocol,
+      password: ENV['REDIS_AUTH_TOKEN']
+    )
     service_token_cache_class = Adapters::RedisCacheAdapter
   rescue URI::InvalidURIError
     puts "could not parse a valid Redis URI from #{url} - falling back to file log"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,15 @@ RUN bundle install --jobs 20 --retry 5
 COPY . .
 ADD . $RAILS_ROOT
 
+# install kubectl as described at
+# https://kubernetes.io/docs/tasks/tools/install-kubectl/
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+RUN touch /etc/apt/sources.list.d/kubernetes.list
+RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
+RUN apt-get update
+RUN apt-get install -y kubectl
+
 
 # allow access to port 3000
 ENV APP_PORT 3000


### PR DESCRIPTION
We weren't installing kubectl by default. We are after this PR.

Elasticache Redis supports authentication via an AuthToken, and uses TLS for secure transmission.
This means we need to make a few changes to the Redis connection initialisation. 