### PR TITLE
Use connection.set instead of connection.append

### DIFF
--- a/app/services/adapters/redis_cache_adapter.rb
+++ b/app/services/adapters/redis_cache_adapter.rb
@@ -4,7 +4,7 @@ class Adapters::RedisCacheAdapter
   end
 
   def self.put(key, value)
-    connection.append(key, value)
+    connection.set(key, value)
   end
 
   private

--- a/spec/services/adapters/redis_cache_adapter_spec.rb
+++ b/spec/services/adapters/redis_cache_adapter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Adapters::RedisCacheAdapter do
   let(:given_key) { 'key' }
-  let(:mock_connection) { double('mock connection', get: 'get result', append: 'append result') }
+  let(:mock_connection) { double('mock connection', get: 'get result', set: 'set result') }
 
   describe '.connection' do
     it 'returns the x.service_token_cache_redis value from Rails config' do
@@ -31,13 +31,13 @@ describe Adapters::RedisCacheAdapter do
       allow(described_class).to receive(:connection).and_return(mock_connection)
     end
 
-    it 'calls append on the connection with the given key and value' do
-      expect(mock_connection).to receive(:append).with(given_key, given_value)
+    it 'calls set on the connection with the given key and value' do
+      expect(mock_connection).to receive(:set).with(given_key, given_value)
       described_class.put(given_key, given_value)
     end
 
-    it 'returns the result of calling connection.append' do
-      expect(described_class.put(given_key, given_value)).to eq('append result')
+    it 'returns the result of calling connection.set' do
+      expect(described_class.put(given_key, given_value)).to eq('set result')
     end
   end
 end


### PR DESCRIPTION
Repeated cache puts with the same key were appending new data to
existing data, when they should have been replacing it. This
caused the JSON to be unparseable, meaning that the cache was
unusable - thus causing the runner to wait several hundred ms on
each request, rather than the 1 or 2 ms you'd expect for a cached
value.

This PR fixes the issue