### PR TITLE
Use validation_url and template_context for emails

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -29,7 +29,7 @@ class EmailsController < ApplicationController
 
     email.mark_as_used
 
-    render json: { email_details: email.encrypted_payload }, status: :ok
+    render json: { encrypted_details: email.encrypted_payload }, status: :ok
   end
 
   private

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -6,6 +6,7 @@ class EmailsController < ApplicationController
                            encrypted_email: params[:encrypted_email],
                            service_slug: params[:service_slug],
                            encrypted_payload: params[:encrypted_details],
+                           validation_url: params[:validation_url],
                            expires_at: expires_at,
                            validity: 'valid')
 

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -7,6 +7,7 @@ class EmailsController < ApplicationController
                            service_slug: params[:service_slug],
                            encrypted_payload: params[:encrypted_details],
                            validation_url: params[:validation_url],
+                           template_context: params[:template_context],
                            expires_at: expires_at,
                            validity: 'valid')
 

--- a/app/controllers/signins_controller.rb
+++ b/app/controllers/signins_controller.rb
@@ -6,6 +6,7 @@ class SigninsController < ApplicationController
                                email: params[:email],
                                encrypted_email: params[:encrypted_email],
                                validation_url: params[:validation_url],
+                               template_context: params[:template_context],
                                expires_at: expires_at)
 
     if magic_link.save

--- a/app/controllers/signins_controller.rb
+++ b/app/controllers/signins_controller.rb
@@ -5,6 +5,7 @@ class SigninsController < ApplicationController
     magic_link = MagicLink.new(service_slug: params[:service_slug],
                                email: params[:email],
                                encrypted_email: params[:encrypted_email],
+                               validation_url: params[:validation_url],
                                expires_at: expires_at)
 
     if magic_link.save

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -2,7 +2,7 @@ class Email < ApplicationRecord
   validates :service_slug, :email, :encrypted_payload, :expires_at, presence: true
 
   def confirmation_link
-    "https://#{service_slug}#{ENV['FORM_URL_SUFFIX']}/savereturn/email/confirm/#{id}"
+    "#{validation_url}/return/setup/email/confirm/#{id}"
   end
 
   def send_confirmation_email

--- a/app/models/magic_link.rb
+++ b/app/models/magic_link.rb
@@ -1,6 +1,6 @@
 class MagicLink < ApplicationRecord
   def magic_link
-    "https://#{service_slug}#{ENV['FORM_URL_SUFFIX']}/return/magiclink/#{id}"
+    "#{validation_url}/return/magiclink/#{id}"
   end
 
   def send_magic_link_email

--- a/app/services/save_and_return/confirmation_email_sender.rb
+++ b/app/services/save_and_return/confirmation_email_sender.rb
@@ -2,11 +2,12 @@ require 'net/http'
 
 module SaveAndReturn
   class ConfirmationEmailSender
-    attr_reader :email, :confirmation_link
+    attr_reader :email, :confirmation_link, :template_context
 
-    def initialize(email:, confirmation_link:)
+    def initialize(email:, confirmation_link:, template_context: {})
       @email = email
       @confirmation_link = confirmation_link
+      @template_context = template_context
     end
 
     def call
@@ -26,7 +27,8 @@ module SaveAndReturn
     def payload
       { service_slug: service_slug,
         email: email,
-        confirmation_link: confirmation_link }
+        confirmation_link: confirmation_link,
+        template_context: template_context }
     end
 
     def service_slug

--- a/app/services/save_and_return/magic_link_email_sender.rb
+++ b/app/services/save_and_return/magic_link_email_sender.rb
@@ -2,11 +2,12 @@ require 'net/http'
 
 module SaveAndReturn
   class MagicLinkEmailSender
-    attr_reader :email, :magic_link
+    attr_reader :email, :magic_link, :template_context
 
-    def initialize(email:, magic_link:)
+    def initialize(email:, magic_link:, template_context: {})
       @email = email
       @magic_link = magic_link
+      @template_context = template_context
     end
 
     def call
@@ -26,7 +27,8 @@ module SaveAndReturn
     def payload
       { service_slug: service_slug,
         email: email,
-        magic_link: magic_link }
+        magic_link: magic_link,
+        template_context: template_context }
     end
 
     def service_slug

--- a/db/migrate/20190513095842_add_validation_url_to_emails.rb
+++ b/db/migrate/20190513095842_add_validation_url_to_emails.rb
@@ -1,0 +1,5 @@
+class AddValidationUrlToEmails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :emails, :validation_url, :text, null: false
+  end
+end

--- a/db/migrate/20190513105144_add_template_context_to_emails.rb
+++ b/db/migrate/20190513105144_add_template_context_to_emails.rb
@@ -1,0 +1,5 @@
+class AddTemplateContextToEmails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :emails, :template_context, :json, null: true
+  end
+end

--- a/db/migrate/20190513123237_add_validation_url_to_magic_links.rb
+++ b/db/migrate/20190513123237_add_validation_url_to_magic_links.rb
@@ -1,0 +1,5 @@
+class AddValidationUrlToMagicLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :magic_links, :validation_url, :text, null: false
+  end
+end

--- a/db/migrate/20190513134041_add_template_context_to_magic_links.rb
+++ b/db/migrate/20190513134041_add_template_context_to_magic_links.rb
@@ -1,0 +1,5 @@
+class AddTemplateContextToMagicLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :magic_links, :template_context, :json, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_13_095842) do
+ActiveRecord::Schema.define(version: 2019_05_13_105144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2019_05_13_095842) do
     t.datetime "updated_at", null: false
     t.text "encrypted_email", null: false
     t.text "validation_url", null: false
+    t.json "template_context"
     t.index ["service_slug", "encrypted_email"], name: "index_emails_on_service_slug_and_encrypted_email"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_08_144516) do
+ActiveRecord::Schema.define(version: 2019_05_13_095842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2019_05_08_144516) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "encrypted_email", null: false
+    t.text "validation_url", null: false
     t.index ["service_slug", "encrypted_email"], name: "index_emails_on_service_slug_and_encrypted_email"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_13_123237) do
+ActiveRecord::Schema.define(version: 2019_05_13_134041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2019_05_13_123237) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "validation_url", null: false
+    t.json "template_context"
     t.index ["service_slug", "encrypted_email"], name: "index_magic_links_on_service_slug_and_encrypted_email"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_13_105144) do
+ActiveRecord::Schema.define(version: 2019_05_13_123237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2019_05_13_105144) do
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "validation_url", null: false
     t.index ["service_slug", "encrypted_email"], name: "index_magic_links_on_service_slug_and_encrypted_email"
   end
 

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EmailsController, type: :controller do
         encrypted_email: 'encrypted:jane-doe@example.com',
         encrypted_details: '64c0b8afa7e93d51c1fc5fe82cac4a690927ee1aa5883b985',
         duration: 30,
-        link_template: '',
+        validation_url: 'https://example.com',
       }
     end
 
@@ -47,6 +47,7 @@ RSpec.describe EmailsController, type: :controller do
           expect(record.encrypted_payload).to eq(json_hash[:encrypted_details])
           expect(record.expires_at).to_not be_blank
           expect(record.validity).to eq('valid')
+          expect(record.validation_url).to eq('https://example.com')
         end
 
         it 'returns a 201 status' do
@@ -75,6 +76,7 @@ RSpec.describe EmailsController, type: :controller do
                         encrypted_email: 'encrypted:jane-doe@example.com',
                         service_slug: service_slug,
                         encrypted_payload: '64c0b8afa7e93d51c1fc5fe82cac4a690927ee1aa5883b985',
+                        validation_url: 'https://example.com',
                         expires_at: Time.now + 20.minutes,
                         validity: 'valid')
         end
@@ -85,6 +87,7 @@ RSpec.describe EmailsController, type: :controller do
                         encrypted_email: 'encrypted:jane-doe@example.com',
                         service_slug: service_slug,
                         encrypted_payload: '64c0b8afa7e93d51c1fc5fe82cac4a690927ee1aa5883b985',
+                        validation_url: 'https://example.com',
                         expires_at: Time.now + 20.minutes,
                         validity: 'valid')
         end
@@ -143,6 +146,7 @@ RSpec.describe EmailsController, type: :controller do
                       encrypted_email: 'encrypted:user@example.com',
                       service_slug: 'service-slug',
                       encrypted_payload: 'foo',
+                      validation_url: 'https://example.com',
                       expires_at: 28.days.from_now,
                       validity: 'valid')
       end
@@ -180,6 +184,7 @@ RSpec.describe EmailsController, type: :controller do
                       encrypted_email: 'encrypted:user@example.com',
                       service_slug: 'service-slug',
                       encrypted_payload: 'foo',
+                      validation_url: 'https://example.com',
                       expires_at: 10.days.ago,
                       validity: 'valid')
       end
@@ -198,6 +203,7 @@ RSpec.describe EmailsController, type: :controller do
                       encrypted_email: 'encrypted:user@example.com',
                       service_slug: 'service-slug',
                       encrypted_payload: 'foo',
+                      validation_url: 'https://example.com',
                       expires_at: 10.days.from_now,
                       validity: 'used')
       end
@@ -216,6 +222,7 @@ RSpec.describe EmailsController, type: :controller do
                       encrypted_email: 'encrypted:user@example.com',
                       service_slug: 'service-slug',
                       encrypted_payload: 'foo',
+                      validation_url: 'https://example.com',
                       expires_at: 10.days.from_now,
                       validity: 'superseded')
       end

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -29,6 +29,29 @@ RSpec.describe EmailsController, type: :controller do
     end
 
     context 'with a valid JSON body' do
+      context 'when template_context is provided' do
+        let(:json_hash) do
+          {
+            email: 'jane-doe@example.com',
+            encrypted_email: 'encrypted:jane-doe@example.com',
+            encrypted_details: '64c0b8afa7e93d51c1fc5fe82cac4a690927ee1aa5883b985',
+            duration: 30,
+            validation_url: 'https://example.com',
+            template_context: {"a":true,"b":1,"c":"foo"}
+          }
+        end
+
+        it 'sets record values correctly' do
+          post_request
+
+          record = Email.last
+
+          expect(record.template_context['a']).to eq(true)
+          expect(record.template_context['b']).to eq(1)
+          expect(record.template_context['c']).to eq('foo')
+        end
+      end
+
       context 'when the email record does not exist' do
         it 'persists the record' do
           expect do

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe EmailsController, type: :controller do
         post :confirm, params: { service_slug: 'service-slug', email_token: email.id }
 
         expect(response).to be_successful
-        expect(JSON.parse(response.body)).to eql({ 'email_details' => 'foo' })
+        expect(JSON.parse(response.body)).to eql({ 'encrypted_details' => 'foo' })
       end
 
       it 'marks record as used' do

--- a/spec/controllers/save_returns_controller_spec.rb
+++ b/spec/controllers/save_returns_controller_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe SaveReturnsController, type: :controller do
           MagicLink.create!(service_slug: 'service-slug',
                             email: 'user@example.com',
                             encrypted_email: 'encrypted:user@example.com',
+                            validation_url: 'https://example.com',
                             expires_at: 2.hours.from_now)
         end
 

--- a/spec/controllers/save_returns_controller_spec.rb
+++ b/spec/controllers/save_returns_controller_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe SaveReturnsController, type: :controller do
                         email: 'user@example.com',
                         encrypted_email: 'encrypted:user@example.com',
                         encrypted_payload: 'encrypted:payload',
+                        validation_url: 'https://example.com',
                         expires_at: 2.hours.from_now)
         end
 

--- a/spec/controllers/signins_controller_spec.rb
+++ b/spec/controllers/signins_controller_spec.rb
@@ -54,6 +54,27 @@ RSpec.describe SigninsController do
       end
     end
 
+    context 'with template_context provided' do
+      let(:json_hash) do
+        {
+          email: 'user@example.com',
+          encrypted_email: 'encrypted:user@example.com',
+          validation_url: 'https://example.com',
+          template_context: {a: true, b: 1, c: 'foo'}
+        }
+      end
+
+      it 'pesists attributes correctly' do
+        do_post!
+
+        record = MagicLink.last
+
+        expect(record.template_context['a']).to eql(true)
+        expect(record.template_context['b']).to eql(1)
+        expect(record.template_context['c']).to eql('foo')
+      end
+    end
+
     describe 'if magic link for email already exists' do
       let!(:previous_magic_link) do
         MagicLink.create!(service_slug: 'service-slug',

--- a/spec/controllers/signins_controller_spec.rb
+++ b/spec/controllers/signins_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe SigninsController do
     let(:json_hash) do
       {
         email: 'user@example.com',
-        encrypted_email: 'encrypted:user@example.com'
+        encrypted_email: 'encrypted:user@example.com',
+        validation_url: 'https://example.com'
       }
     end
 
@@ -58,6 +59,7 @@ RSpec.describe SigninsController do
         MagicLink.create!(service_slug: 'service-slug',
                           email: 'user@example.com',
                           encrypted_email: 'encrypted:user@example.com',
+                          validation_url: 'https://example.com',
                           expires_at: 24.hours.from_now)
       end
 
@@ -84,6 +86,7 @@ RSpec.describe SigninsController do
       MagicLink.create!(service_slug: 'service-slug',
                         email: 'user@example.com',
                         encrypted_email: 'encrypted:user@example.com',
+                        validation_url: 'https://example.com',
                         expires_at: 24.hours.from_now)
     end
 
@@ -135,6 +138,7 @@ RSpec.describe SigninsController do
           MagicLink.create!(service_slug: 'service-slug',
                             email: 'user@example.com',
                             encrypted_email: 'encrypted:user@example.com',
+                            validation_url: 'https://example.com',
                             validity: 'used',
                             expires_at: 24.hours.from_now)
         end
@@ -157,6 +161,7 @@ RSpec.describe SigninsController do
           MagicLink.create!(service_slug: 'service-slug',
                             email: 'user@example.com',
                             encrypted_email: 'encrypted:user@example.com',
+                            validation_url: 'https://example.com',
                             expires_at: 10.hours.ago)
         end
 

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Email, type: :model do
       described_class.create!(email: 'user@example.com',
                               encrypted_email: 'encrypted:user@example.com',
                               encrypted_payload: 'encrypted:payload',
+                              validation_url: 'https://example.com',
                               expires_at: 10.days.from_now,
                               service_slug: 'my-service')
     end

--- a/spec/models/magic_link_spec.rb
+++ b/spec/models/magic_link_spec.rb
@@ -1,27 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe Email, type: :model do
-  it { should validate_presence_of(:service_slug) }
-  it { should validate_presence_of(:email) }
-  it { should validate_presence_of(:encrypted_payload) }
-  it { should validate_presence_of(:expires_at) }
-
-  describe '#confirmation_link' do
+RSpec.describe MagicLink, type: :model do
+  describe '#magic_link' do
     subject do
       described_class.create!(email: 'user@example.com',
                               encrypted_email: 'encrypted:user@example.com',
-                              encrypted_payload: 'encrypted:payload',
                               validation_url: 'https://example.com',
                               expires_at: 10.days.from_now,
                               service_slug: 'my-service')
     end
 
     it 'returns correct link' do
-      expect(subject.confirmation_link).to eql("https://example.com/return/setup/email/confirm/#{subject.id}")
+      expect(subject.magic_link).to eql("https://example.com/return/magiclink/#{subject.id}")
     end
   end
 
-  describe '#send_confirmation_email' do
+  describe '#send_magic_link_email' do
     let(:email) { 'user@example.com'  }
     let(:service_slug) { 'my-service'  }
 
@@ -32,10 +26,10 @@ RSpec.describe Email, type: :model do
     it 'calls sender' do
       mock = double('sender')
 
-      expect(SaveAndReturn::ConfirmationEmailSender).to receive(:new).with(email: email, confirmation_link: subject.confirmation_link).and_return(mock)
+      expect(SaveAndReturn::MagicLinkEmailSender).to receive(:new).with(email: email, magic_link: subject.magic_link).and_return(mock)
       expect(mock).to receive(:call)
 
-      subject.send_confirmation_email
+      subject.send_magic_link_email
     end
   end
 end

--- a/spec/services/save_and_return/confirmation_email_sender_spec.rb
+++ b/spec/services/save_and_return/confirmation_email_sender_spec.rb
@@ -12,11 +12,16 @@ RSpec.describe SaveAndReturn::ConfirmationEmailSender do
   describe '#call' do
     subject do
       described_class.new(email: 'user@example.com',
-                          confirmation_link: 'https://example.com/foo')
+                          confirmation_link: 'https://example.com/foo',
+                          template_context: {
+                            a: true,
+                            b: 1,
+                            c: 'foo'
+                          })
     end
 
     it 'makes correct request' do
-      expected_body = '{"service_slug":"datastore","email":"user@example.com","confirmation_link":"https://example.com/foo"}'
+      expected_body = '{"service_slug":"datastore","email":"user@example.com","confirmation_link":"https://example.com/foo","template_context":{"a":true,"b":1,"c":"foo"}}'
 
       expected_headers = {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby', 'X-Access-Token'=>'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1NDYzMDA4MDB9.xknzXLc6El1fxdwmm9-r2QvZMINKWG1zrC9nt6b2-5E' }
 

--- a/spec/services/save_and_return/magic_link_email_sender_spec.rb
+++ b/spec/services/save_and_return/magic_link_email_sender_spec.rb
@@ -12,11 +12,16 @@ RSpec.describe SaveAndReturn::MagicLinkEmailSender do
   describe '#call' do
     subject do
       described_class.new(email: 'user@example.com',
-                          magic_link: 'https://example.com/foo')
+                          magic_link: 'https://example.com/foo',
+                          template_context: {
+                            a: true,
+                            b: 1,
+                            c: 'foo'
+                          })
     end
 
     it 'makes correct request' do
-      expected_body = '{"service_slug":"datastore","email":"user@example.com","magic_link":"https://example.com/foo"}'
+      expected_body = '{"service_slug":"datastore","email":"user@example.com","magic_link":"https://example.com/foo","template_context":{"a":true,"b":1,"c":"foo"}}'
 
       expected_headers = {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby', 'X-Access-Token'=>'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1NDYzMDA4MDB9.xknzXLc6El1fxdwmm9-r2QvZMINKWG1zrC9nt6b2-5E' }
 

--- a/spec/services/save_return/magic_link_email_sender_spec.rb
+++ b/spec/services/save_return/magic_link_email_sender_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SaveAndReturn::MagicLinkEmailSender do
+  around :each do |example|
+    now = Time.new(2019, 1, 1).utc
+
+    Timecop.freeze(now) do
+      example.run
+    end
+  end
+
+  describe '#call' do
+    subject do
+      described_class.new(email: 'user@example.com',
+                          magic_link: 'https://example.com/foo')
+    end
+
+    it 'makes correct request' do
+      expected_body = '{"service_slug":"datastore","email":"user@example.com","magic_link":"https://example.com/foo"}'
+
+      expected_headers = {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby', 'X-Access-Token'=>'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1NDYzMDA4MDB9.xknzXLc6El1fxdwmm9-r2QvZMINKWG1zrC9nt6b2-5E' }
+
+      stub = stub_request(:post, 'http://localhost:3000/save_return/email_magic_links')
+              .with(headers: expected_headers, body: expected_body)
+
+      subject.call
+
+      expect(stub).to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
Dependent on changes in https://github.com/ministryofjustice/fb-submitter/pull/24

- Use `validation_url` as base url for confirmation link
- `template_context` passed to worker which will pass to notify to allow emails to be more customisable
- Tweak json response for email confirmation