### PR TITLE
Create mobile code

### DIFF
--- a/app/controllers/mobiles_controller.rb
+++ b/app/controllers/mobiles_controller.rb
@@ -5,9 +5,15 @@ class MobilesController < ApplicationController
                              encrypted_email: params[:encrypted_email],
                              encrypted_payload: params[:encrypted_details],
                              expires_at: Time.now + (params[:duration].to_i).hours,
-                             code: '12345')
+                             code: mobile_code)
 
     mobile_data.save!
     render json: {}, status: :created
+  end
+
+  private
+
+  def mobile_code
+    Array.new(5) { rand(10) }.join
   end
 end

--- a/app/controllers/mobiles_controller.rb
+++ b/app/controllers/mobiles_controller.rb
@@ -4,7 +4,7 @@ class MobilesController < ApplicationController
                              mobile: params[:mobile],
                              encrypted_email: params[:encrypted_email],
                              encrypted_payload: params[:encrypted_details],
-                             expires_at: Time.now + (params[:duration].to_i).hours,
+                             expires_at: expires_at,
                              code: mobile_code)
 
     mobile_data.save!
@@ -15,5 +15,21 @@ class MobilesController < ApplicationController
 
   def mobile_code
     Array.new(5) { rand(10) }.join
+  end
+
+  def expires_at
+    Time.now + duration
+  end
+
+  def duration
+    if params[:duration]
+      params[:duration].to_i.minutes
+    else
+      default_duration
+    end
+  end
+
+  def default_duration
+    30.minutes
   end
 end

--- a/app/controllers/mobiles_controller.rb
+++ b/app/controllers/mobiles_controller.rb
@@ -1,4 +1,13 @@
 class MobilesController < ApplicationController
   def create
+    mobile_data = Mobile.new(service_slug: params[:service_slug],
+                             mobile: params[:mobile],
+                             encrypted_email: params[:encrypted_email],
+                             encrypted_payload: params[:encrypted_details],
+                             expires_at: Time.now + (params[:duration].to_i).hours,
+                             code: '12345')
+
+    mobile_data.save!
+    render json: {}, status: :created
   end
 end

--- a/app/controllers/mobiles_controller.rb
+++ b/app/controllers/mobiles_controller.rb
@@ -1,0 +1,4 @@
+class MobilesController < ApplicationController
+  def create
+  end
+end

--- a/app/models/mobile.rb
+++ b/app/models/mobile.rb
@@ -1,0 +1,4 @@
+class Mobile < ApplicationRecord
+  validates :service_slug, :mobile, :encrypted_email, :encrypted_payload,
+            :expires_at, :code, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,6 @@ Rails.application.routes.draw do
 
   post '/service/:service_slug/savereturn/signin/email', to: 'signins#email'
   post '/service/:service_slug/savereturn/signin/magiclink', to: 'signins#magic_link'
+
+  post '/service/:service_slug/savereturn/mobile/add', to: 'mobiles#create'
 end

--- a/db/migrate/20190516194026_create_mobiles.rb
+++ b/db/migrate/20190516194026_create_mobiles.rb
@@ -1,0 +1,15 @@
+class CreateMobiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :mobiles, id: :uuid do |t|
+      t.string :service_slug
+      t.string :mobile
+      t.text :encrypted_email
+      t.text :encrypted_payload
+      t.datetime :expires_at
+      t.string :validity, null: false, default: 'valid'
+      t.string :code, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_13_134041) do
+ActiveRecord::Schema.define(version: 2019_05_16_194026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -21,9 +21,9 @@ ActiveRecord::Schema.define(version: 2019_05_13_134041) do
     t.string "service_slug"
     t.string "encrypted_payload"
     t.datetime "expires_at"
-    t.string "validity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "validity"
     t.text "encrypted_email", null: false
     t.text "validation_url", null: false
     t.json "template_context"
@@ -41,6 +41,18 @@ ActiveRecord::Schema.define(version: 2019_05_13_134041) do
     t.text "validation_url", null: false
     t.json "template_context"
     t.index ["service_slug", "encrypted_email"], name: "index_magic_links_on_service_slug_and_encrypted_email"
+  end
+
+  create_table "mobiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "service_slug"
+    t.string "mobile"
+    t.text "encrypted_email"
+    t.text "encrypted_payload"
+    t.datetime "expires_at"
+    t.string "validity", default: "valid", null: false
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "save_returns", force: :cascade do |t|

--- a/spec/controllers/mobiles_controller_spec.rb
+++ b/spec/controllers/mobiles_controller_spec.rb
@@ -1,5 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe MobilesController, type: :controller do
+  before :each do
+    allow_any_instance_of(ApplicationController).to receive(:verify_token!)
+    request.env['CONTENT_TYPE'] = 'application/json'
+  end
 
+  let(:service_slug) { 'my-service' }
+
+  describe 'POST /service/:service_slug/savereturn/mobile/add' do
+    context 'when the mobile record does not exist' do
+      let(:post_request) do
+        post :create, params: { service_slug: service_slug,
+                                mobile: '07777 111 222',
+                                encrypted_email: 'encryptedEmail',
+                                encrypted_details: 'encryptedDetails',
+                                duration: '20' }
+      end
+
+      it 'persists the record' do
+        expect do
+          post_request
+        end.to change(Mobile, :count).by(1)
+      end
+
+      it 'returns a 201 status' do
+        post_request
+        expect(response).to have_http_status(201)
+      end
+
+      it 'returns an empty json object' do
+        post_request
+        expect(response.body).to eql('{}')
+      end
+
+      it 'sets record values correctly' do
+        post_request
+        record = Mobile.last
+
+        expect(record.mobile).to eq(request.parameters[:mobile])
+        expect(record.encrypted_email).to eq(request.parameters[:encrypted_email])
+        expect(record.service_slug).to eq('my-service')
+        expect(record.encrypted_payload).to eq(request.parameters[:encrypted_details])
+        expect(record.expires_at).to_not be_blank
+        expect(record.code).to_not be_blank
+        expect(record.validity).to eq('valid')
+      end
+    end
+  end
 end

--- a/spec/controllers/mobiles_controller_spec.rb
+++ b/spec/controllers/mobiles_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MobilesController, type: :controller do
                                 mobile: '07777 111 222',
                                 encrypted_email: 'encryptedEmail',
                                 encrypted_details: 'encryptedDetails',
-                                duration: '20' }
+                                duration: '30' }
       end
 
       it 'persists the record' do

--- a/spec/controllers/mobiles_controller_spec.rb
+++ b/spec/controllers/mobiles_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MobilesController, type: :controller do
+
+end

--- a/spec/models/mobile_spec.rb
+++ b/spec/models/mobile_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Mobile, type: :model do
+  it { should validate_presence_of(:service_slug) }
+  it { should validate_presence_of(:mobile) }
+  it { should validate_presence_of(:encrypted_email) }
+  it { should validate_presence_of(:encrypted_payload) }
+  it { should validate_presence_of(:expires_at) }
+  it { should validate_presence_of(:code) }
+end


### PR DESCRIPTION
This PR creates a code for a user to confirm their mobile number when setting up save and return. Note this PR does not include the recent changes made to the Save & Return API design