### PR TITLE
Add minimum test coverage with formatted output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :test do
   gem 'faker'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'simplecov'
+  gem 'simplecov-console', require: false
   gem 'webmock'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    ansi (1.5.0)
     arel (9.0.0)
     builder (3.2.3)
     byebug (10.0.2)
@@ -201,6 +202,10 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-console (0.5.0)
+      ansi
+      simplecov
+      terminal-table
     simplecov-html (0.10.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -209,11 +214,14 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -247,6 +255,7 @@ DEPENDENCIES
   sentry-raven
   shoulda-matchers (~> 3.1)
   simplecov
+  simplecov-console
   timecop
   tzinfo-data
   webmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,15 @@ RSpec.configure do |config|
 end
 
 require 'simplecov'
+require 'simplecov-console'
+
 SimpleCov.start do
   add_filter '/config/'
   add_filter '/spec/'
 end
+SimpleCov.minimum_coverage 99
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::Console
+])


### PR DESCRIPTION
It was pointed out that this repo is one of the most crucial of the backend microservices. As such, I've added a minimum code coverage at the current coverage level to ensure code coverage does not decrease. We can work towards 100% coverage in subsequent PRs.

Also added a nice formatter to clearly display coverage results:
<img width="1047" alt="Screenshot 2019-06-25 at 14 23 31" src="https://user-images.githubusercontent.com/2160769/60102239-2f1db080-9755-11e9-9f1a-551cffc76a0f.png">
