### PR TITLE
Add Kubernetes readiness probe

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ActionController::API
+  def show
+    render plain: 'healthy'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
     mount Rswag::Api::Engine => '/api-docs'
   end
 
+  get '/health', to: 'health#show'
+
   get '/service/:service_slug/user/:user_id', to: 'user_data#show'
   post '/service/:service_slug/user/:user_id', to: 'user_data#create_or_update'
 

--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -23,6 +23,13 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe HealthController do
+  describe '#show' do
+    it 'returns 200 OK' do
+      get :show
+      expect(response.status).to eq(200)
+      expect(response.body).to eq('healthy')
+    end
+  end
+end


### PR DESCRIPTION
Even though we are doing rolling deploys, it seems that traffic is being served
to the pods before Rails has booted. So this is still resulting in downtime.

By exposing an endpoint for the readiness probe to test, we can ensure that the application
will be ready to serve traffic by the time it is registered with the load balancer.