### PR TITLE
Don't authenticate in Development

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -52,11 +52,7 @@ module Concerns
     end
 
     def disable_jwt?
-      swagger || false
-    end
-
-    def swagger
-      Rails.env.development? && request.referrer.include?('api-docs')
+      Rails.env.development?
     end
 
     def get_service_token(service_slug)


### PR DESCRIPTION
JWT authentication through the Token Service Cache is coupled to Kubernetes.

To use this app in local stack testing we need to disable JWT authentication
until the implementation can be made more generic.