### PR TITLE
Use either RDS certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ RUN bundle install --jobs 2 --retry 3 --no-cache ${BUNDLE_FLAGS}
 
 COPY . .
 
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem ./rds-combined-ca-bundle.pem
+ADD https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem ./rds-ca-2019-root.pem
+ADD https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem ./rds-ca-2015-root.pem
+RUN cat ./rds-ca-2019-root.pem > ./rds-ca-bundle-root.crt
+RUN cat ./rds-ca-2015-root.pem >> ./rds-ca-bundle-root.crt
 
 RUN chown -R 1001:appgroup /app
 USER 1001

--- a/config/database.yml
+++ b/config/database.yml
@@ -81,4 +81,4 @@ test:
 #
 production:
   <<: *default
-  url: <%= "#{ENV['DATABASE_URL']}?sslmode=verify-full&sslrootcert=#{Rails.root.join("rds-combined-ca-bundle.pem")}" %>
+  url: "<%= "#{ENV['DATABASE_URL']}?sslmode=verify-full&sslrootcert=#{Rails.root.join("rds-ca-bundle-root.crt")}" %>"


### PR DESCRIPTION
- test RDS instance is now using the 2019 cert
- I have tested this with the previous 2015 cert
- so application code is compatible with either certs
- we can roll this out and can update the RDS certificates whenever we wish