### PR TITLE
V2 auth

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -17,13 +17,9 @@ module Concerns
 
     private
 
-    # may raise any of:
-    #   TokenInvalidError
-    #   TokenNotPresentError
-    #
-    def verify_token!(token: request.headers['x-access-token'],
-                      args: params,
-                      leeway: ENV['MAX_IAT_SKEW_SECONDS'])
+    def verify_token!
+      token = request.headers['x-access-token']
+      leeway = ENV['MAX_IAT_SKEW_SECONDS']
 
       raise Exceptions::TokenNotPresentError.new unless token.present?
 

--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -18,13 +18,21 @@ module Concerns
     private
 
     def verify_token!
+      if request.headers['x-access-token-v2']
+        verify_v2
+      else
+        verify_v1
+      end
+    end
+
+    def verify_v1
       token = request.headers['x-access-token']
       leeway = ENV['MAX_IAT_SKEW_SECONDS']
 
       raise Exceptions::TokenNotPresentError.new unless token.present?
 
       begin
-        hmac_secret = get_service_token(params[:service_slug])
+        hmac_secret = service_token(params[:service_slug])
         payload, header = JWT.decode(
           token,
           hmac_secret,
@@ -47,8 +55,44 @@ module Concerns
       end
     end
 
-    def get_service_token(service_slug)
-      ServiceTokenService.get(service_slug)
+    def verify_v2
+      token = request.headers['x-access-token-v2']
+      leeway = ENV['MAX_IAT_SKEW_SECONDS']
+
+      raise Exceptions::TokenNotPresentError.new unless token.present?
+
+      begin
+        hmac_secret = public_key(params[:service_slug])
+        payload, header = JWT.decode(
+          token,
+          hmac_secret,
+          true,
+          {
+            exp_leeway: leeway,
+            algorithm: 'RS256'
+          }
+        )
+
+        # NOTE: verify_iat used to be in the JWT gem, but was removed in v2.2
+        # so we have to do it manually
+        iat_skew = payload['iat'].to_i - Time.current.to_i
+        if iat_skew.abs > leeway.to_i
+          raise Exceptions::TokenNotValidError.new
+        end
+
+      rescue StandardError => e
+        raise Exceptions::TokenNotValidError.new
+      end
+    end
+
+    def service_token(service_slug)
+      service = ServiceTokenService.new(service_slug: service_slug)
+      service.get
+    end
+
+    def public_key(service_slug)
+      service = ServiceTokenService.new(service_slug: service_slug)
+      service.public_key
     end
   end
 end

--- a/app/services/adapters/service_token_cache_client.rb
+++ b/app/services/adapters/service_token_cache_client.rb
@@ -2,7 +2,7 @@ require 'net/http'
 
 module Adapters
   class ServiceTokenCacheClient
-    attr_accessor :root_url
+    attr_reader :root_url
 
     def initialize(params={})
       @root_url = params[:root_url] || ENV['SERVICE_TOKEN_CACHE_ROOT_URL']
@@ -14,8 +14,24 @@ module Adapters
       JSON.parse(response.body).fetch('token') if response.code.to_i == 200
     end
 
+    def public_key_for(service_slug)
+      url = public_key_uri(service_slug)
+      response = Net::HTTP.get_response(url)
+
+      return unless response.code.to_i == 200
+
+      public_key_string = Base64.strict_decode64(JSON.parse(response.body).fetch('token'))
+      OpenSSL::PKey::RSA.new(public_key_string)
+    end
+
+    private
+
     def service_token_uri(service_slug)
-      URI.join(@root_url, '/service/', service_slug)
+      URI.join(root_url, '/service/', service_slug)
+    end
+
+    def public_key_uri(service_slug)
+      URI.join(root_url, '/service/v2/', service_slug)
     end
   end
 end

--- a/app/services/service_token_service.rb
+++ b/app/services/service_token_service.rb
@@ -1,9 +1,21 @@
 class ServiceTokenService
-  def self.get(service_slug)
+  attr_reader :service_slug
+
+  def initialize(service_slug:)
+    @service_slug = service_slug
+  end
+
+  def get
     client.get(service_slug)
   end
 
-  def self.client
+  def public_key
+    client.public_key_for(service_slug)
+  end
+
+  private
+
+  def client
     @client ||= Adapters::ServiceTokenCacheClient.new
   end
 end

--- a/spec/controllers/concerns/jwt_authentication_spec.rb
+++ b/spec/controllers/concerns/jwt_authentication_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.describe 'Concerns::JWTAuthentication' do
+  let(:service_token) { 'service-token' }
+  let(:service_slug) { 'service-slug' }
+  let(:body) { response.body }
+  let(:parsed_body) { JSON.parse(response.body) }
+  let(:payload) { {} }
+  let(:headers) { {} }
+  let(:encoded_private_key) { 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBM1NUQjJMZ2gwMllrdCtMcXo5bjY5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlCmx6MXh4cEpPTGV0ckxncW4zN2hNak5ZMC9uQUNjTWR1RUg5S1hycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW4KYmRtKzZzNUt2TGdVTk43WFZjZVA5UHVxWnlzeENWQTRUbm1MRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdApQYkFneFdBZmVTTGxiN0JQbHNIbS9IMEFBTCtuYmFPQ2t3dnJQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05aCnNUVlFhbzRYd2hlYnVkaGx2TWlrRVczMldLZ0t1SEhXOHpkdlU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0wKQTNZaDhMSTVHeWQ5cDZmMjdNZmxkZ1VJSFN4Y0pweTFKOEFQcXdJREFRQUJBb0lCQUU5ZjJTQVRmemlraWZ0aQp2RXRjZnlMN0EzbXRKd2c4dDI2cDcyT3czMUg0RWg4NHlOaWFHbE5ld2lialAvWW5wdmU2NitjRkg4SlBxK0NWCkJHRnhmdDBmampXZkRrZTNiTTVaUjdaQUVDaW8vay9pMEpveU5MK015ZkNRMWRmZ1FFUXV1L0gvdnJzSEdyT3cKRW5YQVZIUzg1enlCWWczbjM4QmxjVkw4V2s4R3FlMGxCUU5RSks5dSt5ckc5NEpoUTVoMTZubXlyQ0xpWkhSTAoyWS94MTdDL3BCN1VlUVFWeDZ4aVZSdVdmT1FoWlNmT2IzRHpsYldhc2owa2pTaHdWWDFQVG5sU0lxQXo5T3krClY5M013VFBtbVNOOGFiL0pGVlVBUzhtckM2elcxc0NjcFVUTFZHRVZBUFBJcWpjMmZFKzdLVGNjVDFzWkt0MWIKb2p1R2xSa0NnWUVBL2ZuK3VZcCtxSzdiQmxkUTZCSmNsNXpkR0xybXRrWFFZR096d2cvN21zd0NVdUM3UFpGYQpJV0xBSGM4QU85eDZvUFQ0SzFPNnQzYVBtMW8vUTR1S1N2NWNGK3EwaThMemVQM2JxdnowQXBXekdPVFdiMXg5CnNBRzNIOCtIT3JNS0NXVWl3bm5pUG1PMDNXUUY0dmFoWUd1WXYzSkNSNTYxanBJOFRkMkx6QmNDZ1lFQTN1ZkwKKzdqNGE2elVBOUNrak5wSnB2VkxyQk8ydUpiRHk5NXBpSzlCU3FIellQSEw3VVBWTExFaXRGWlNBWlRWRzFHMwpWbUNxMVoraXhCcTRST0t2VldyME1mSklsUlEvQXBQY3NwVXJjRTRPcnAxRkEyNjlLdXhhdnI5dmpLMCtIbWNRClEydWNRWWdUeWFXQlNZeW9laW04QWQ2UlpJRzVLQ25uTVlhNThZMENnWUVBNUp6VG5VLzlFdm5TVGJMck1QclcKUGVNRlllMWJIMWRZYW10VXM2cVBZSmVpdjlkcXM5RFN3SnFUTkVIUWhCSENrSC94bzQ2SzAvbjA2bkloNERzTApFTlpGTDRJbFltanBvRTlpSEZmMWpSNFRTS1UwSUttd3VXM1IyT0NGYVdFZjk3VUJ4T3pScWpjMTV0TFNPYXFuCk9KT2h1ekt1VnFtVjQrL2VPSGprRGFFQ2dZQUdMVFloeTRaV3RYdEtmOFdQZ1p6NDIyTTFhWFp1dHY3Rjcydk4KTmM0QlcydDdERGd5WXViTlRqcy85QVJodHRZUTQ3ckkwZlRwNW5xRUpKbG1qMEY4aEhJdjBCN2l3cVRjVld5UQpKa0lGNHFQVmd0WWV1anJUcmFqMkVDZnZKZjNLcWVCeGZkSGVudjZ0WDhDdFlSQnFFaTM3ZjBkWUdhQWYxTWxyClBlaDVJUUtCZ1FDbmN6YU8xcUx3VktyeUc4TzF5ZUhDSjQzT1h6SENwN3VnOE90aS9ScmhWZ08wSCtEdVpXUzUKSWhydHpUeU56MExyQTdibVFLTWZ4Y3k5Y29LOG9zZnVma1pZenJxM1ZFa0ViUCtjRWdLcGtlTDlaY2RSbXZ3WQozSTZkMUlOWVUwMldPSzhiRUJBNElJNGc0ak9ZcjJJUjFzb2lWZ0E2YnVya3E3QnMrUm41WFE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=' }
+  let(:encoded_public_key) { 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==' }
+  let(:public_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_public_key)) }
+  let(:fake_client) do
+    double('Adapters::ServiceTokenCacheClient')
+  end
+
+  controller do
+    include Concerns::ErrorHandling
+    include Concerns::JWTAuthentication
+
+    def index
+      head :ok
+    end
+  end
+
+  before do
+    allow(Adapters::ServiceTokenCacheClient).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive(:get).with('service-slug').and_return(service_token)
+    allow(fake_client).to receive(:public_key_for).with(service_slug).and_return(public_key)
+
+    request.headers.merge!(headers)
+    get :index, params: { service_slug: service_slug }
+  end
+
+  context 'with no x-access-token header' do
+    it 'has status 401' do
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    describe 'the body' do
+      it 'is valid JSON' do
+        expect { parsed_body }.not_to raise_error
+      end
+
+      describe 'the errors key' do
+        it 'has a message indicating the header is not present' do
+          expect(parsed_body.fetch('errors').first.fetch('title')).to eq(
+            I18n.t(:title, scope: [:error_messages, :token_not_present])
+          )
+        end
+      end
+    end
+  end
+
+  context 'with a header called x-access-token' do
+    let(:headers) do
+      {
+        'content-type' => 'application/json',
+        'x-access-token' => token
+      }
+    end
+    let(:algorithm) { 'HS256' }
+
+    context 'when valid' do
+      let(:iat) { Time.current.to_i }
+      let(:token) do
+        JWT.encode payload.merge(iat: iat), service_token, algorithm
+      end
+
+      it 'does not respond with an unauthorized or forbidden status' do
+        expect(response).not_to have_http_status(:unauthorized)
+        expect(response).not_to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when not valid' do
+      let(:token) { 'invalid token' }
+
+      context 'when the timestamp is older than MAX_IAT_SKEW_SECONDS' do
+        let(:iat) { Time.current.to_i - 1.year }
+        let(:token) do
+          JWT.encode payload.merge(iat: iat), service_token, algorithm
+        end
+
+        it 'has status 403' do
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        describe 'the body' do
+          it 'is valid JSON' do
+            expect { parsed_body }.not_to raise_error
+          end
+
+          describe 'the errors key' do
+            it 'has a message indicating the token is invalid' do
+              expect(parsed_body.fetch('errors').first.fetch('title')).to eq(
+                I18n.t(:title, scope: [:error_messages, :token_not_valid])
+              )
+            end
+          end
+        end
+      end
+
+      context 'when timestamp is > MAX_IAT_SKEW_SECONDS seconds in the future' do
+        let(:iat) { Time.current.to_i + (ENV['MAX_IAT_SKEW_SECONDS'].to_i + 1) }
+        let(:token) do
+          JWT.encode payload, service_token, algorithm
+        end
+
+        it 'has status 403' do
+          expect(response.status).to eq(403)
+        end
+
+        describe 'the body' do
+          it 'is valid JSON' do
+            expect { parsed_body }.not_to raise_error
+          end
+
+          describe 'the errors key' do
+            it 'has a message indicating the token is invalid' do
+              expect(parsed_body.fetch('errors').first.fetch('title')).to eq(
+                I18n.t(:title, scope: [:error_messages, :token_not_valid])
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+
+  context 'with a header called x-access-token-v2' do
+    let(:headers) do
+      {
+        'content-type' => 'application/json',
+        'x-access-token-v2' => token
+      }
+    end
+    let(:algorithm) { 'RS256' }
+    let(:private_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)) }
+
+    context 'when valid' do
+      let(:iat) { Time.current.to_i }
+      let(:token) do
+        JWT.encode payload.merge(iat: iat), private_key, algorithm
+      end
+
+      it 'does not respond with an unauthorized or forbidden status' do
+        expect(response).not_to have_http_status(:unauthorized)
+        expect(response).not_to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/services/adapters/service_token_cache_client_spec.rb
+++ b/spec/services/adapters/service_token_cache_client_spec.rb
@@ -21,23 +21,19 @@ RSpec.describe Adapters::ServiceTokenCacheClient do
     end
   end
 
+  subject { described_class.new(root_url: 'http://www.example.com') }
+
   describe '#get' do
     let(:service_slug) { 'my-service' }
     let(:response_code) { '200' }
     let(:mock_response) { double('response', body: '{"token": "token value"}', code: response_code) }
 
     before do
-      allow(subject).to receive(:service_token_uri).with(service_slug).and_return('http://service/token/url')
       allow(Net::HTTP).to receive(:get_response).and_return(mock_response)
     end
 
-    it 'gets the service_token_uri for the given service_slug' do
-      expect(subject).to receive(:service_token_uri).with(service_slug).and_return('http://service/token/url')
-      subject.get(service_slug)
-    end
-
     it 'makes a GET request to the service_token_uri' do
-      expect(Net::HTTP).to receive(:get_response).with('http://service/token/url').and_return(mock_response)
+      expect(Net::HTTP).to receive(:get_response).with(URI('http://www.example.com/service/my-service')).and_return(mock_response)
       subject.get(service_slug)
     end
 
@@ -68,15 +64,19 @@ RSpec.describe Adapters::ServiceTokenCacheClient do
     end
   end
 
-  describe '#service_token_uri' do
-    subject { described_class.new(root_url: 'http://my.root.url/') }
-
-    it 'returns a URI' do
-      expect(subject.service_token_uri('my-service')).to be_a(URI)
+  describe '#public_key_for' do
+    let(:service_slug) { 'my-service' }
+    let(:encoded_public_key) do
+      'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=='
+    end
+    let(:mock_response) do
+      double('response', body: {token: encoded_public_key}.to_json, code: 200)
     end
 
-    it 'is the @root_url followed by /service/(service_slug)' do
-      expect(subject.service_token_uri('my-service').to_s).to eq('http://my.root.url/service/my-service')
+    it 'returns public key' do
+      expect(Net::HTTP).to receive(:get_response).with(URI('http://www.example.com/service/v2/my-service')).and_return(mock_response)
+
+      subject.public_key_for(service_slug)
     end
   end
 end

--- a/spec/services/service_token_service_spec.rb
+++ b/spec/services/service_token_service_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe ServiceTokenService do
+end


### PR DESCRIPTION
- this implements public key auth through the header `x-access-token-v2`
- `x-access-token` header remains in place for backwards compatibility
- this will be deployed first but not used. it will be used once runner starts sending new header