### PR TITLE
Remove v1 authentication code

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -20,48 +20,16 @@ module Concerns
     private
 
     def verify_token!
-      if request.headers['x-access-token-v2']
-        verify_v2
-      else
-        verify_v1
+      unless request.headers['x-access-token-v2']
+        raise Exceptions::TokenNotPresentError
       end
+
+      verify
     end
 
-    def verify_v1
-      token = request.headers['x-access-token']
-      leeway = ENV['MAX_IAT_SKEW_SECONDS']
-
-      raise Exceptions::TokenNotPresentError.new unless token.present?
-
-      begin
-        hmac_secret = service_token(params[:service_slug])
-        @jwt_payload, _header = JWT.decode(
-          token,
-          hmac_secret,
-          true,
-          {
-            exp_leeway: leeway,
-            algorithm: 'HS256'
-          }
-        )
-
-        # NOTE: verify_iat used to be in the JWT gem, but was removed in v2.2
-        # so we have to do it manually
-        iat_skew = @jwt_payload['iat'].to_i - Time.current.to_i
-        if iat_skew.abs > leeway.to_i
-          raise Exceptions::TokenNotValidError.new
-        end
-
-      rescue StandardError => e
-        raise Exceptions::TokenNotValidError.new
-      end
-    end
-
-    def verify_v2
+    def verify
       token = request.headers['x-access-token-v2']
       leeway = ENV['MAX_IAT_SKEW_SECONDS']
-
-      raise Exceptions::TokenNotPresentError.new unless token.present?
 
       begin
         hmac_secret = public_key(params[:service_slug])
@@ -77,12 +45,12 @@ module Concerns
 
         # NOTE: verify_iat used to be in the JWT gem, but was removed in v2.2
         # so we have to do it manually
-
         iat_skew = @jwt_payload['iat'].to_i - Time.current.to_i
+
         if iat_skew.abs > leeway.to_i
           raise Exceptions::TokenNotValidError.new
         end
-      rescue StandardError => e
+      rescue StandardError
         raise Exceptions::TokenNotValidError.new
       end
     end

--- a/spec/controllers/concerns/jwt_authentication_spec.rb
+++ b/spec/controllers/concerns/jwt_authentication_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Concerns::JWTAuthentication' do
     get :index, params: { service_slug: service_slug }
   end
 
-  context 'with no x-access-token header' do
+  context 'with no x-access-token-v2 header' do
     it 'has status 401' do
       expect(response).to have_http_status(:unauthorized)
     end
@@ -52,19 +52,20 @@ RSpec.describe 'Concerns::JWTAuthentication' do
     end
   end
 
-  context 'with a header called x-access-token' do
+  context 'with a header called x-access-token-v2' do
     let(:headers) do
       {
         'content-type' => 'application/json',
-        'x-access-token' => token
+        'x-access-token-v2' => token
       }
     end
-    let(:algorithm) { 'HS256' }
+    let(:algorithm) { 'RS256' }
+    let(:private_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)) }
 
     context 'when valid' do
       let(:iat) { Time.current.to_i }
       let(:token) do
-        JWT.encode payload.merge(iat: iat), service_token, algorithm
+        JWT.encode payload.merge(iat: iat), private_key, algorithm
       end
 
       it 'does not respond with an unauthorized or forbidden status' do
@@ -74,6 +75,7 @@ RSpec.describe 'Concerns::JWTAuthentication' do
     end
 
     context 'when not valid' do
+      let(:algorithm) { 'HS256' }
       let(:token) { 'invalid token' }
 
       context 'when the timestamp is older than MAX_IAT_SKEW_SECONDS' do
@@ -102,9 +104,17 @@ RSpec.describe 'Concerns::JWTAuthentication' do
       end
 
       context 'when timestamp is > MAX_IAT_SKEW_SECONDS seconds in the future' do
+        let(:headers) do
+          {
+            'content-type' => 'application/json',
+            'x-access-token-v2' => token
+          }
+        end
+        let(:algorithm) { 'RS256' }
+        let(:private_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)) }
         let(:iat) { Time.current.to_i + (ENV['MAX_IAT_SKEW_SECONDS'].to_i + 1) }
         let(:token) do
-          JWT.encode payload, service_token, algorithm
+          JWT.encode payload, private_key, algorithm
         end
 
         it 'has status 403' do
@@ -124,29 +134,6 @@ RSpec.describe 'Concerns::JWTAuthentication' do
             end
           end
         end
-      end
-    end
-  end
-
-  context 'with a header called x-access-token-v2' do
-    let(:headers) do
-      {
-        'content-type' => 'application/json',
-        'x-access-token-v2' => token
-      }
-    end
-    let(:algorithm) { 'RS256' }
-    let(:private_key) { OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)) }
-
-    context 'when valid' do
-      let(:iat) { Time.current.to_i }
-      let(:token) do
-        JWT.encode payload.merge(iat: iat), private_key, algorithm
-      end
-
-      it 'does not respond with an unauthorized or forbidden status' do
-        expect(response).not_to have_http_status(:unauthorized)
-        expect(response).not_to have_http_status(:forbidden)
       end
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/DaEXYM24/109-switch-to-new-auth-method-deprecate-old-auth-method-4-4)

V2 is now in use so we no longer need any related v1 authentication
code.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>