### PR TITLE
Add metrics adapter to user data store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby File.read(".ruby-version").strip
 
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'rails', '~> 6.0.3'
-gem 'metrics_adapter'
+gem 'metrics_adapter', '0.2.0'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.3'
 gem 'jwt'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby File.read(".ruby-version").strip
 
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'rails', '~> 6.0.3'
+gem 'metrics_adapter'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.3'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    metrics_adapter (0.1.0)
+    metrics_adapter (0.2.0)
       activesupport
       keen
       mixpanel-ruby
@@ -247,7 +247,7 @@ DEPENDENCIES
   guard-shell
   jwt
   listen
-  metrics_adapter
+  metrics_adapter (= 0.2.0)
   pg (>= 0.18, < 2.0)
   puma (~> 4.3)
   rails (~> 6.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -103,6 +105,9 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jwt (2.2.1)
+    keen (1.1.1)
+      addressable (~> 2.5)
+      multi_json (~> 1.12)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -115,11 +120,17 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    metrics_adapter (0.1.0)
+      activesupport
+      keen
+      mixpanel-ruby
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    mixpanel-ruby (2.2.2)
     msgpack (1.3.3)
+    multi_json (1.14.1)
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.2)
@@ -132,6 +143,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -235,6 +247,7 @@ DEPENDENCIES
   guard-shell
   jwt
   listen
+  metrics_adapter
   pg (>= 0.18, < 2.0)
   puma (~> 4.3)
   rails (~> 6.0.3)
@@ -249,4 +262,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/config/initializers/metrics_adapter.rb
+++ b/config/initializers/metrics_adapter.rb
@@ -1,0 +1,17 @@
+require 'metrics_adapter/rails'
+
+MetricsAdapter.configure do |config|
+  config.adapter = :mixpanel
+  config.adapter_options = {
+    secret: ENV['METRICS_ACCESS_KEY']
+  }
+  config.extra_attributes = { app: 'Datastore' }
+  config.logger = Rails.logger
+  config.trackers = %i(slow_request)
+  config.thresholds = { slow_request: 1_000 }
+
+  ## Only send metrics if is production
+  ##
+  block = -> { ENV['HOSTNAME'].to_s.include?('live-production') }
+  config.conditionals = { slow_request: block }
+end

--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -56,3 +56,8 @@ spec:
               secretKeyRef:
                 name: fb-user-datastore-api-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+          - name: METRICS_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-user-datastore-api-secrets-{{ .Values.environmentName }}
+                key: metrics_access_key

--- a/deploy/fb-user-datastore-chart/templates/secrets.yaml
+++ b/deploy/fb-user-datastore-chart/templates/secrets.yaml
@@ -15,3 +15,4 @@ metadata:
 type: Opaque
 data:
   token: {{ .Values.service_token }}
+  metrics_access_key: {{ .Values.metrics_access_key }}


### PR DESCRIPTION
[Trello Card](https://trello.com/c/5cXWL11V/342-request-delay-between-pages)

## Description

This PR adds the [metrics adapter gem](https://github.com/ministryofjustice/metrics-adapter) - the [first version](https://github.com/ministryofjustice/metrics-adapter/pull/1).

## Caveats

I am considering 1 second as a slow request and I added via config of the gem.

## Next PR

- [ ] Add the mixpanel secret to our git crypt repo.