### PR TITLE
Trigger acceptance tests after specs have passed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,13 @@ workflows:
   version: 2
   test_and_build:
     jobs:
+      - test
       - trigger_acceptance_tests:
+          requires:
+            - test
           filters:
             branches:
               only: master
-      - test
       - build_and_deploy_to_test:
           requires:
             - test


### PR DESCRIPTION
We only want the acceptance tests to run if the spec tests have succeeded