### PR TITLE
Use POD_NAME in deployment step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
             PLATFORM_ENV: test
             DEPLOYMENT_ENV: dev
             K8S_NAMESPACE: formbuilder-platform-test-dev
+            POD_NAME: fb-user-datastore-api-test-dev
           command: './deploy-scripts/bin/deploy'
       - run:
           name: deploy to test production
@@ -50,6 +51,7 @@ jobs:
             PLATFORM_ENV: test
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-test-production
+            POD_NAME: fb-user-datastore-api-test-production
           command: './deploy-scripts/bin/deploy'
   build_and_deploy_to_live:
     working_directory: ~/circle/git/fb-user-datastore
@@ -80,6 +82,7 @@ jobs:
             PLATFORM_ENV: live
             DEPLOYMENT_ENV: dev
             K8S_NAMESPACE: formbuilder-platform-live-dev
+            POD_NAME: fb-user-datastore-api-live-dev
           command: './deploy-scripts/bin/deploy'
       - run:
           name: deploy to live production
@@ -88,6 +91,7 @@ jobs:
             PLATFORM_ENV: live
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-live-production
+            POD_NAME: fb-user-datastore-api-live-production
           command: './deploy-scripts/bin/deploy'
   trigger_acceptance_tests:
     docker:


### PR DESCRIPTION
The pod name for the datastore is fb-user-datastore-api so we need to add that to the deployment steps for each environment.