### PR TITLE
Trigger acceptance tests after build and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,24 +90,24 @@ jobs:
             K8S_NAMESPACE: formbuilder-platform-live-production
           command: './deploy-scripts/bin/deploy'
   trigger_acceptance_tests:
-    docker:
-      - image: circleci/ruby:latest
+    working_directory: ~/circle/git/fb-user-datastore
+    docker: *ecr_base_image
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "9f:66:01:8b:19:3c:0e:40:6f:b8:e0:11:a4:43:09:af"
+      - run:
+          name: cloning deploy scripts
+          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
       - run:
           name: "Trigger Acceptance Tests"
-          command: "curl -u ${CIRCLE_TOKEN}: -X POST https://circleci.com/api/v2/project/github/ministryofjustice/fb-acceptance-tests/pipeline -H 'Content-Type: application/json' -H 'Accept: application/json'"
+          command: './deploy-scripts/bin/acceptance_tests'
 
 workflows:
   version: 2
   test_and_build:
     jobs:
       - test
-      - trigger_acceptance_tests:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
       - build_and_deploy_to_test:
           requires:
             - test
@@ -115,10 +115,16 @@ workflows:
             branches:
               only:
                 - master
+      - trigger_acceptance_tests:
+          requires:
+            - build_and_deploy_to_test
+          filters:
+            branches:
+              only: master
       - confirm_live_deploy:
           type: approval
           requires:
-            - build_and_deploy_to_test
+            - trigger_acceptance_tests
       - build_and_deploy_to_live:
           requires:
             - confirm_live_deploy


### PR DESCRIPTION
We now want the acceptance tests to run only after a successful rollout and restart