### PR TITLE
Increase the number of replicas in each environment

### DIFF
--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: "fb-user-datastore-api-{{ .Values.environmentName }}"
 spec:
-  replicas: 2
+  replicas: 6
   selector:
     matchLabels:
       app: "fb-user-datastore-api-{{ .Values.environmentName }}"


### PR DESCRIPTION
We feel that the datastore is part of a bottleneck issue in the platform. Increase the replicas to 6 per environment to so that we can monitor whether this helps