### PR TITLE
Increase the number of replicas in each environment

### DIFF
--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: "fb-user-datastore-api-{{ .Values.environmentName }}"
 spec:
-  replicas: 6
+  replicas: 10
   selector:
     matchLabels:
       app: "fb-user-datastore-api-{{ .Values.environmentName }}"


### PR DESCRIPTION
After load testing the tool and investigating mroe the issues we are
having we decide to increase this number to 10 replicas.

Each replica has a 5 connection pool to the database, so 10 replicas will use
50% postgres single cluster max connection capabilities (which is 100 max connections).

Will also help to mitigate the root cause which is the runner
making a lot of unecessary requests to the datastore