### PR TITLE
Increase number of datastore pods to 20 in production namespace

### DIFF
--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: "fb-user-datastore-api-{{ .Values.environmentName }}"
 spec:
-  replicas: 10
+  replicas: 20
   selector:
     matchLabels:
       app: "fb-user-datastore-api-{{ .Values.environmentName }}"


### PR DESCRIPTION
Story: https://trello.com/c/9NsCMUl5/1339-increase-number-of-datastore-pods-to-20-in-the-production-namespace