### PR TITLE
Migrate to use new Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem 'metrics_adapter', '0.2.0'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 5.3'
 gem 'jwt'
-gem 'sentry-raven'
+gem 'sentry-rails', '~> 4.4.0'
+gem 'sentry-ruby', '~> 4.4.2'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,11 +88,15 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     ffi (1.15.0)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -213,8 +217,16 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
     ruby2_keywords (0.0.4)
-    sentry-raven (3.1.2)
+    sentry-rails (4.4.0)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.4.0.pre.beta)
+    sentry-ruby (4.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.4.2)
+    sentry-ruby-core (4.4.2)
+      concurrent-ruby
+      faraday
     shellany (0.0.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
@@ -266,7 +278,8 @@ DEPENDENCIES
   puma (~> 5.3)
   rails (~> 6.1.3)
   rspec-rails (>= 3.5.0)
-  sentry-raven
+  sentry-rails (~> 4.4.0)
+  sentry-ruby (~> 4.4.2)
   shoulda-matchers (~> 4.5)
   simplecov
   simplecov-console

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -4,7 +4,7 @@ module Concerns
 
     included do
       rescue_from StandardError do |e|
-        Raven.capture_exception(e)
+        Sentry.capture_exception(e)
 
         args = { message: e.message }
         unless Rails.env.production?

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, 'X-Access-Token']

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,13 @@
-Raven.configure do |config|
-  config.dsn = ENV['SENTRY_DSN']
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.logger =  Logger.new(STDOUT)
 
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  config.sanitize_fields += ['X-Access-Token']
+  config.traces_sample_rate = 1
+  config.before_send = lambda do |event, _hint|
+    if event.request && event.request.data
+      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      event.request.data = filter.filter(event.request.data)
+    end
+    event
+  end
 end

--- a/spec/controllers/concerns/error_handling_spec.rb
+++ b/spec/controllers/concerns/error_handling_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe ActionController::Base do
       end
     end
 
-    it 'calls raven (sentry) with exception' do
-      expect(Raven).to receive(:capture_exception).and_return(nil)
+    it 'calls sentry with exception' do
+      expect(Sentry).to receive(:capture_exception).and_return(nil)
       get :index, format: :json
     end
   end
@@ -24,8 +24,8 @@ RSpec.describe ActionController::Base do
       end
     end
 
-    it 'does not call raven (sentry)' do
-      expect(Raven).to_not receive(:capture_exception)
+    it 'does not call Sentry' do
+      expect(Sentry).to_not receive(:capture_exception)
       get :index, format: :json
     end
   end


### PR DESCRIPTION
This adds the new sentry rails and ruby gems.

Configure the cleaning of the sensitive parameters.

Also enable performance monitoring for the upcoming trial.