### PR TITLE
Increase Initial Delay for Kubernetes Readiness probe

### DIFF
--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 5
+          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
         # non-secret env vars


### PR DESCRIPTION
The datastore is throwing errors during the draining of nodes that cloud
platform does periodically. A potential reason for this is that it is
failing the readiness probe that Kubernetes does in order to ascertain
whether a pod has been created or not.

Increase the initial delay period to 15 seconds in order to give the pod
more time to reach ready state.

We should be able to leave this in place to see if the acceptance tests
run without failures for a few nights.

More information about this issue can be found [here](https://github.com/ministryofjustice/cloud-platform/issues/2873).