### PR TITLE
Filter payload from logging and sentry

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, 'X-Access-Token']
+Rails.application.config.filter_parameters += [:password, :payload, 'X-Access-Token']


### PR DESCRIPTION
Even though the payload is encrypted we should probably filter it from
the logs and also from Sentry