### PR TITLE
Add rollout strategy to kubernetes config

### DIFF
--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -6,6 +6,11 @@ metadata:
   name: "fb-user-datastore-api-{{ .Values.environmentName }}"
 spec:
   replicas: 25
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: "fb-user-datastore-api-{{ .Values.environmentName }}"


### PR DESCRIPTION
maxSurge: 100% means that 100% of the number of new replicas is allowed
to be created over the total number of replicas set.

In other words despite the config saying only 25 replicas can exist at
at any one time, during rollout a further 25 are allowed to exist at the
same time.

maxUnavailable: 50% means that at least 50% of the new replicas must be
available before scaling down of the old ones commences