### PR TITLE
Revert "Add rollout strategy to kubernetes config"

### DIFF
--- a/deploy/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy/fb-user-datastore-chart/templates/deployment.yaml
@@ -6,11 +6,6 @@ metadata:
   name: "fb-user-datastore-api-{{ .Values.environmentName }}"
 spec:
   replicas: 25
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 50%
   selector:
     matchLabels:
       app: "fb-user-datastore-api-{{ .Values.environmentName }}"


### PR DESCRIPTION
Reverts ministryofjustice/fb-user-datastore#342

This seems to have only made it worse, so return it to how it was.