### PR TITLE
Ignore multiple ActiveRecord::ConcurrentMigrationError during deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ ENV APP_PORT 3000
 EXPOSE $APP_PORT
 
 ARG RAILS_ENV=production
-CMD bundle exec rake db:migrate && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0
+CMD bundle exec rake db:migrate:ignore_concurrent && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0

--- a/lib/tasks/migrate_ignore_concurrent.rake
+++ b/lib/tasks/migrate_ignore_concurrent.rake
@@ -1,0 +1,16 @@
+namespace :db do
+  namespace :migrate do
+    desc 'Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors'
+    task ignore_concurrent: :environment do
+      # DB migrations are called as the entry command in the Dockerfile
+      # Since we have multiple pods for the datastore we only need the first migration
+      # to run and any proceeding ActiveRecord::ConcurrentMigrationError
+      # can rescued instead of sending a Sentry alert.
+      begin
+        Rake::Task['db:migrate'].invoke
+      rescue ActiveRecord::ConcurrentMigrationError
+        # Move along
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have multiple pods for the datastore running in each of our
namespaces. Each time we deploy we throw an ActiveRecord::ConcurrentMigrationError
as the first pod available will be the one that manages to successfully
run the migration. Any following pods will just throw an error.

We can mitigate this by catching the ActiveRecord::ConcurrentMigrationError
and this should not trigger any Sentry alerts.