### PR TITLE
Unpin Docker version in CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run:
           name: make spec


### PR DESCRIPTION
Removing the version will always use the default.
[Trello Ticket](https://trello.com/c/LQokBApj)