### PR TITLE
Use new RDS instance URL

### DIFF
--- a/deploy-eks/fb-user-datastore-chart/templates/cronjob_db_sweeper.yaml
+++ b/deploy-eks/fb-user-datastore-chart/templates/cronjob_db_sweeper.yaml
@@ -27,7 +27,7 @@ spec:
               - name: DATABASE_URL
                 valueFrom:
                   secretKeyRef:
-                    name: rds-instance-formbuilder-user-datastore-{{ .Values.environmentName }}
+                    name: rds-instance-formbuilder-user-datastore-2-{{ .Values.environmentName }}
                     key: url
               - name: SECRET_KEY_BASE
                 valueFrom:

--- a/deploy-eks/fb-user-datastore-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-user-datastore-chart/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: rds-instance-formbuilder-user-datastore-{{ .Values.environmentName }}
+                name: rds-instance-formbuilder-user-datastore-2-{{ .Values.environmentName }}
                 key: url
           - name: SECRET_KEY_BASE
             valueFrom:


### PR DESCRIPTION
This swaps to use the new Graviton RDS instance that was recently created