### PR TITLE
Add 'checkout' step to circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ jobs:
     docker: *ecr_base_image
     resource_class: large
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:
@@ -137,6 +138,7 @@ jobs:
   smoke_tests:
     docker: *ecr_base_image
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:


### PR DESCRIPTION
### Add 'checkout' step to CircleCI config

Github have recently rotated their RSA SSH host key. As a result, the public key is no longer up to date in the `known_host` file.

The 'checkout' step automatically adds the required authenticity keys for interacting with Github. Adding this job allows the acceptance test and smoke tests steps to interact with Github.

CircleCI run:
https://app.circleci.com/pipelines/github/ministryofjustice/fb-user-datastore/1446/workflows/810a0208-a039-4ca2-9a6d-f6f1663ea3c7
