### PR TITLE
Add db sweeper extension and specs

### DIFF
--- a/app/models/saved_form.rb
+++ b/app/models/saved_form.rb
@@ -1,5 +1,27 @@
 class SavedForm < ApplicationRecord
   self.implicit_order_column = 'created_at'
   validates :service_slug, presence: true
-  validates :user_id, presence: true
+
+  def invalidated?
+    return true if self.active == false
+    return true if self.attempts > 3
+    return true if self.user_id.blank? || self.user_token.blank?
+    false
+  end
+
+  def invalidate_user_fields!
+    self.user_id = ""
+    self.user_token = ""
+    self.user_data_payload = ""
+    self.secret_answer = ""
+    self.active = false
+
+    self.save!
+  end
+
+  def increment_attempts!
+    self.attempts += 1
+
+    self.save!
+  end
 end

--- a/app/services/db_sweeper.rb
+++ b/app/services/db_sweeper.rb
@@ -1,11 +1,23 @@
 class DbSweeper
   def call
     UserData.where("created_at < ?", age_threshold).destroy_all
+    SavedForm.where("created_at < ?", invalidation_threshold).each do |record| 
+      record.invalidate_user_fields!
+    end
+    SavedForm.where("created_at < ?", destroy_saved_progress_threshold).destroy_all
   end
 
   private
 
   def age_threshold
     28.days.ago
+  end
+
+  def invalidation_threshold
+    28.days.ago
+  end
+
+  def destroy_saved_progress_threshold
+    60.days.ago
   end
 end

--- a/spec/factories/saved_form.rb
+++ b/spec/factories/saved_form.rb
@@ -1,0 +1,22 @@
+require 'modules/crypto'
+
+FactoryBot.define do
+  factory :saved_form do
+    service_slug { 'my-service' }
+    user_id { SecureRandom.uuid }
+    user_token { SecureRandom.uuid }
+    user_data_payload { Base64.encode64(
+      Crypto::AES256.encrypt(
+        key: 'abcdef0123456789', data: {'some_key' => 'some value'}.to_json
+      )
+    ) }
+    page_slug { 'some_page/' }
+    secret_question { 'bar' }
+    secret_answer { 'foo' }
+    email { 'email@email.com' }
+    attempts { 0 }
+    active { true }
+    created_at { Time.current }
+    updated_at { nil }
+  end
+end

--- a/spec/models/saved_form_spec.rb
+++ b/spec/models/saved_form_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SavedForm, type: :model do
     end
   end
 
-  context '#invalidate_user_fields' do
+  describe '#invalidate_user_fields' do
     let(:model) { SavedForm.new(user_id: '123', user_token: '456', user_data_payload: 'q1 => answer', secret_answer: 'hello', active: true, service_slug: 'some_slug') }
 
     it 'should remove sensitive data and invalidate the record' do

--- a/spec/models/saved_form_spec.rb
+++ b/spec/models/saved_form_spec.rb
@@ -11,38 +11,46 @@ RSpec.describe SavedForm, type: :model do
   describe '#invalidated' do
     let(:model) { SavedForm.new(user_id: '123', user_token: '456', user_data_payload: 'q1 => answer', secret_answer: 'hello', active: true, service_slug: 'some_slug') }
     
-    it 'should consider the model invalidated if user id is empty' do
-      expect(model.invalidated?).to be(false)
-      model.user_id = nil
-      expect(model.invalidated?).to be(true)
-      model.user_id = ""
-      expect(model.invalidated?).to be(true)
+    context 'user id is empty' do
+      it 'should consider the model invalidated' do
+        expect(model.invalidated?).to be(false)
+        model.user_id = nil
+        expect(model.invalidated?).to be(true)
+        model.user_id = ""
+        expect(model.invalidated?).to be(true)
+      end
     end
 
-    it 'should consider the model invalidated if user token is empty' do
-      expect(model.invalidated?).to be(false)
-      model.user_token = nil
-      expect(model.invalidated?).to be(true)
-      model.user_token = ""
-      expect(model.invalidated?).to be(true)
+    context 'user token is empty' do
+      it 'should consider the model invalidated' do
+        expect(model.invalidated?).to be(false)
+        model.user_token = nil
+        expect(model.invalidated?).to be(true)
+        model.user_token = ""
+        expect(model.invalidated?).to be(true)
+      end
     end
 
-    it 'should consider the model invalidated if attempts >3' do
-      expect(model.invalidated?).to be(false)
-      model.increment_attempts!
-      expect(model.invalidated?).to be(false)
-      model.increment_attempts!
-      expect(model.invalidated?).to be(false)
-      model.increment_attempts!
-      expect(model.invalidated?).to be(false)
-      model.increment_attempts!
-      expect(model.invalidated?).to be(true)
+    context 'attempts above max limit (3)' do
+      it 'should consider the model invalidated' do
+        expect(model.invalidated?).to be(false)
+        model.increment_attempts!
+        expect(model.invalidated?).to be(false)
+        model.increment_attempts!
+        expect(model.invalidated?).to be(false)
+        model.increment_attempts!
+        expect(model.invalidated?).to be(false)
+        model.increment_attempts!
+        expect(model.invalidated?).to be(true)
+      end
     end
 
-    it 'should consider the model invalidated if marked inactive' do
-      expect(model.invalidated?).to be(false)
-      model.active = false
-      expect(model.invalidated?).to be(true)
+    context 'record marked inactive' do
+      it 'should consider the model invalidated' do
+        expect(model.invalidated?).to be(false)
+        model.active = false
+        expect(model.invalidated?).to be(true)
+      end
     end
   end
 

--- a/spec/models/saved_form_spec.rb
+++ b/spec/models/saved_form_spec.rb
@@ -2,10 +2,63 @@ require 'rails_helper'
 
 RSpec.describe SavedForm, type: :model do
   it { should validate_presence_of(:service_slug) }
-  it { should validate_presence_of(:user_id) }
 
   it 'should set the default values' do
     expect(subject.attempts).to eq(0)
     expect(subject.active).to eq(true)
+  end
+
+  context '#invalidated' do
+    let(:model) { SavedForm.new(user_id: '123', user_token: '456', user_data_payload: 'q1 => answer', secret_answer: 'hello', active: true, service_slug: 'some_slug') }
+    
+    it 'should consider the model invalidated if user id is empty' do
+      expect(model.invalidated?).to be(false)
+      model.user_id = nil
+      expect(model.invalidated?).to be(true)
+      model.user_id = ""
+      expect(model.invalidated?).to be(true)
+    end
+
+    it 'should consider the model invalidated if user token is empty' do
+      expect(model.invalidated?).to be(false)
+      model.user_token = nil
+      expect(model.invalidated?).to be(true)
+      model.user_token = ""
+      expect(model.invalidated?).to be(true)
+    end
+
+    it 'should consider the model invalidated if attempts >3' do
+      expect(model.invalidated?).to be(false)
+      model.increment_attempts!
+      expect(model.invalidated?).to be(false)
+      model.increment_attempts!
+      expect(model.invalidated?).to be(false)
+      model.increment_attempts!
+      expect(model.invalidated?).to be(false)
+      model.increment_attempts!
+      expect(model.invalidated?).to be(true)
+    end
+
+    it 'should consider the model invalidated if marked inactive' do
+      expect(model.invalidated?).to be(false)
+      model.active = false
+      expect(model.invalidated?).to be(true)
+    end
+  end
+
+  context '#invalidate_user_fields' do
+    let(:model) { SavedForm.new(user_id: '123', user_token: '456', user_data_payload: 'q1 => answer', secret_answer: 'hello', active: true, service_slug: 'some_slug') }
+
+    it 'should remove sensitive data and invalidate the record' do
+      model.invalidate_user_fields!
+
+      expect(model.user_id.blank?).to be(true)
+      expect(model.user_token.blank?).to be(true)
+      expect(model.user_data_payload.blank?).to be(true)
+      expect(model.secret_answer.blank?).to be(true)
+      expect(model.active).to be(false)
+
+      expect(model.invalidated?).to be(true)
+    end
   end
 end

--- a/spec/models/saved_form_spec.rb
+++ b/spec/models/saved_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SavedForm, type: :model do
     expect(subject.active).to eq(true)
   end
 
-  context '#invalidated' do
+  describe '#invalidated' do
     let(:model) { SavedForm.new(user_id: '123', user_token: '456', user_data_payload: 'q1 => answer', secret_answer: 'hello', active: true, service_slug: 'some_slug') }
     
     it 'should consider the model invalidated if user id is empty' do

--- a/spec/services/db_sweeper_spec.rb
+++ b/spec/services/db_sweeper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DbSweeper do
-  describe '#call' do
+  describe '#call UserData' do
     context 'when there is user data over 28 days old' do
       before :each do
         create(:user_data, created_at: 30.days.ago)
@@ -24,6 +24,59 @@ RSpec.describe DbSweeper do
         expect do
           subject.call
         end.to_not change(UserData, :count)
+      end
+    end
+  end
+
+  describe '#call SavedProgress' do
+    context 'when there is saved progress data over 60 days old' do
+      before :each do
+        create(:saved_form, created_at: 61.days.ago)
+        create(:saved_form, created_at: 5.days.ago)
+      end
+
+      it 'destroys the older records' do
+        expect do
+          subject.call
+        end.to change(SavedForm, :count).by(-1)
+      end
+    end
+
+    context 'when there is no saved progress over 60 days old' do
+      before :each do
+        create(:saved_form, created_at: 59.days.ago)
+      end
+
+      it 'leaves records intact' do
+        expect do
+          subject.call
+        end.to_not change(SavedForm, :count)
+      end
+    end
+
+    context 'invalidating the user data' do
+      before :each do
+        create(:saved_form, created_at: 39.days.ago)
+        create(:saved_form, created_at: 27.days.ago)
+      end
+
+      it 'removes all user data from records over 28 days old' do
+        subject.call
+
+        still_valid = SavedForm.where("created_at > ?", 28.days.ago)
+        expect(still_valid.count).to be(1)
+        expect(still_valid.first.invalidated?).to be(false)
+
+        invalid = SavedForm.where("created_at < ?", 28.days.ago)
+        expect(invalid.count).to be(1)
+        expect(invalid.first.invalidated?).to be(true)
+        expect(invalid.first.user_token.blank?).to be(true)
+      end
+
+      it 'leaves records intact' do
+        expect do
+          subject.call
+        end.to_not change(SavedForm, :count)
       end
     end
   end


### PR DESCRIPTION
Extend the DB sweeper call to remove SavedForm records older than 60 days
Extend the DB sweeper call to invalidate on SavedForm records older than 28 days
Implement invalidate function to blank sensitive data in records, called by sweeper