### PR TITLE
Add routes to invalidate and increment attempts to resume

### DIFF
--- a/app/controllers/save_and_return_controller.rb
+++ b/app/controllers/save_and_return_controller.rb
@@ -15,7 +15,39 @@ class SaveAndReturnController < ApplicationController
 
     render json: {}, status: :not_found, format: :json if @saved == nil and return
 
+    if @saved.invalidated?
+      render json: {}, status: :unprocessable_entity, format: :json and return
+    end
+
     render json: @saved.to_json, status: :ok, format: :json
+  end
+
+  def increment
+    @saved = SavedForm.find(params[:uuid])
+
+    render json: {}, status: :not_found, format: :json if @saved == nil and return
+
+    if @saved.attempts.to_i >= 3 || @saved.invalidated?
+      render json: {}, status: :unprocessable_entity, format: :json and return
+    end
+
+    @saved.increment_attempts!
+
+    render json: {}, status: :ok, format: :json
+  end
+
+  def invalidate
+    @saved = SavedForm.find(params[:uuid])
+
+    render json: {}, status: :not_found, format: :json if @saved == nil and return
+
+    if @saved.invalidated?
+      render json: {}, status: :unprocessable_entity, format: :json and return
+    end
+
+    @saved.invalidate_user_fields!
+
+    render json: {}, status: :accepted, format: :json
   end
 
   def save_progress_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   # save and return v2
   get '/service/:service_slug/saved/:uuid', to: 'save_and_return#show'
   post '/service/:service_slug/saved', to: 'save_and_return#create'
+  post '/service/:service_slug/saved/:uuid/increment', to: 'save_and_return#increment'
+  post '/service/:service_slug/saved/:uuid/invalidate', to: 'save_and_return#invalidate'
+
   #
 
   post '/service/:service_slug/savereturn/setup/email/add', to: 'emails#add'


### PR DESCRIPTION
POST increment
Increments attempt count for a given saved for uuid - used by frontend to increment attempts permanently if the user supplies wrong secret answer

POST invalidate
Invalidates a saved progress record and removes user id and token. Used by frontend after successfully resuming progress

SHOW
Updated to return a status code the frontend can use when requesting a record that has been invalidated so the user can be redirected to relevant error page