### PR TITLE
Add secret question text to saved form

### DIFF
--- a/db/migrate/20230505072509_add_secret_question_text_to_saved_form.rb
+++ b/db/migrate/20230505072509_add_secret_question_text_to_saved_form.rb
@@ -1,0 +1,5 @@
+class AddSecretQuestionTextToSavedForm < ActiveRecord::Migration[6.1]
+  def change
+    add_column :saved_forms, :secret_question_text, :string
+  end
+end

--- a/spec/controllers/save_and_return_controller_spec.rb
+++ b/spec/controllers/save_and_return_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe SaveAndReturnController, type: :controller do
       service_version: "27dc30c9-f7b8-4dec-973a-bd153f6797df",
       user_id: "8acfb3db90002a5fc5b43e71638fc709",
       user_token: "b9cca34d4331399c5f461c0ba1c406aa",
+      secret_question_text: "some text",
       user_data_payload: {
         name_text_1: "Name"
       },
@@ -35,6 +36,15 @@ RSpec.describe SaveAndReturnController, type: :controller do
 
       get :show, params: { service_slug: 'service-slug', uuid: uuid }
       expect(response.status).to be(200)
+      expect(response.body).to include(json_hash[:email])
+      expect(response.body).to include(json_hash[:secret_answer])
+      expect(response.body).to include(json_hash[:secret_question])
+      expect(response.body).to include(json_hash[:secret_question_text])
+      expect(response.body).to include(json_hash[:user_id])
+      expect(response.body).to include(json_hash[:user_token])
+      expect(response.body).to include(json_hash[:service_slug])
+      expect(response.body).to include(json_hash[:service_version])
+      expect(response.body).to include(json_hash[:page_slug])
     end
 
     describe 'when not found' do


### PR DESCRIPTION
We need to add this in order to resolve a validation bug on the front end where the secret question selection radio is cleared, because we never hold the value of the selection only the text it corresponds to. 

Adding this extra field will let the front end store and reference both.