### PR TITLE
Update dependencies and rename main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           command: make spec
       - slack/status: &slack_status
           fail_only: true
-          only_for_branches: master
+          only_for_branches: main
           failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
           include_job_number_field: false
   build_and_push_image:
@@ -123,7 +123,7 @@ jobs:
             K8S_NAMESPACE: formbuilder-platform-live-dev
           command: './deploy-scripts/bin/deploy-eks'
       - slack/status:
-          only_for_branches: master
+          only_for_branches: main
           success_message: ":rocket:  Successfully deployed to Live Dev  :guitar:"
           failure_message: ":alert:  Failed to deploy to Live Dev  :try_not_to_cry:"
           include_job_number_field: false
@@ -145,7 +145,7 @@ jobs:
             K8S_NAMESPACE: formbuilder-platform-live-production
           command: './deploy-scripts/bin/deploy-eks'
       - slack/status:
-          only_for_branches: master
+          only_for_branches: main
           success_message: ":rocket:  Successfully deployed to Live Production  :guitar:"
           failure_message: ":alert:  Failed to deploy to Live Production  :try_not_to_cry:"
           include_job_number_field: false
@@ -190,7 +190,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
       - deploy_to_test_dev:
           context: *context
           requires:
@@ -211,7 +211,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
       - deploy_to_live_production:
           context: *context
           requires:
@@ -219,7 +219,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
       - smoke_tests:
           context: *context
           requires:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,12 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
+
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches: [ '**' ]
   schedule:

--- a/Gemfile
+++ b/Gemfile
@@ -7,13 +7,13 @@ gem 'rails', '~> 7.0.6'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 6.4'
 gem 'jwt'
-gem 'sentry-rails', '~> 5.13.0'
-gem 'sentry-ruby', '~> 5.13.0'
+gem 'sentry-rails', '~> 5.13'
+gem 'sentry-ruby', '~> 5.13'
 gem 'tzinfo-data'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails', '>= 3.5.0'
+  gem 'rspec-rails'
   gem 'dotenv-rails', require: 'dotenv/rails-now'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     nenv (0.3.0)
-    net-imap (0.4.5)
+    net-imap (0.4.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -145,7 +145,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.6.1)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -215,10 +215,10 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    sentry-rails (5.13.0)
+    sentry-rails (5.14.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.13.0)
-    sentry-ruby (5.13.0)
+      sentry-ruby (~> 5.14.0)
+    sentry-ruby (5.14.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shellany (0.0.1)
     shoulda-matchers (5.3.0)
@@ -263,9 +263,9 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 6.4)
   rails (~> 7.0.6)
-  rspec-rails (>= 3.5.0)
-  sentry-rails (~> 5.13.0)
-  sentry-ruby (~> 5.13.0)
+  rspec-rails
+  sentry-rails (~> 5.13)
+  sentry-ruby (~> 5.13)
   shoulda-matchers (~> 5.3)
   simplecov
   simplecov-console

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/ministryofjustice/fb-user-datastore/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/fb-user-datastore/tree/master)
+[![CircleCI](https://circleci.com/gh/ministryofjustice/fb-user-datastore/tree/main.svg?style=svg)](https://circleci.com/gh/ministryofjustice/fb-user-datastore/tree/main)
 
 # fb-user-datastore
 
@@ -26,4 +26,4 @@ make spec
 
 Continuous Integration (CI) is enabled on this project via CircleCI.
 
-On merge to master tests are executed and if green deployed to the test environment. This build can then be promoted to production
+On merge to main tests are executed and if green deployed to the test environment. This build can then be promoted to production


### PR DESCRIPTION
Some more minor bumps to gems to close dependabots.

Reduce noise in dependabot by configuring it to only raise PRs for security versions, and not for version updates.

Renamed `master` branch to `main` and update CircleCI config.