### PR TITLE
Remove data after 27 days

### DIFF
--- a/app/services/db_sweeper.rb
+++ b/app/services/db_sweeper.rb
@@ -10,11 +10,11 @@ class DbSweeper
   private
 
   def age_threshold
-    28.days.ago
+    27.days.ago
   end
 
   def invalidation_threshold
-    28.days.ago
+    27.days.ago
   end
 
   def destroy_saved_progress_threshold

--- a/spec/services/db_sweeper_spec.rb
+++ b/spec/services/db_sweeper_spec.rb
@@ -57,17 +57,17 @@ RSpec.describe DbSweeper do
     context 'invalidating the user data' do
       before :each do
         create(:saved_form, created_at: 39.days.ago)
-        create(:saved_form, created_at: 27.days.ago)
+        create(:saved_form, created_at: 26.days.ago)
       end
 
       it 'removes all user data from records over 28 days old' do
         subject.call
 
-        still_valid = SavedForm.where("created_at > ?", 28.days.ago)
+        still_valid = SavedForm.where("created_at > ?", 27.days.ago)
         expect(still_valid.count).to be(1)
         expect(still_valid.first.invalidated?).to be(false)
 
-        invalid = SavedForm.where("created_at < ?", 28.days.ago)
+        invalid = SavedForm.where("created_at < ?", 27.days.ago)
         expect(invalid.count).to be(1)
         expect(invalid.first.invalidated?).to be(true)
         expect(invalid.first.user_token.blank?).to be(true)


### PR DESCRIPTION
We run the db sweeper every hour, and it removes records created at 28.days.ago

Which means records live 28 days + up to 59 minutes

We delete files using a 28 day retention policy managed by S3, which appears to delete at 00:00 on the 28th day, so it functionally keeps files for 27 days + minutes until midnight

This seems to leave an edge case where you can use save & return to return to your form on the morning of the 28th day, complete your submission successfully and see no errors.

We will see a failed submission where the S3 bucket returns 404 results for the attachments you uploaded 28 days ago. It's possible this isn't the (or the only) reason this can happen but this should prevent one failure case.