### PR TITLE
CDPT-3038: Bump rails from 7.1.5.1 to 7.1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'bootsnap', '>= 1.1.0', require: false
-gem 'rails', '~> 7.1.0'
+gem 'rails', '~> 7.1.5.2'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 6.4'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     msgpack (1.7.2)
     mutex_m (0.3.0)
     nenv (0.3.0)
-    net-imap (0.5.7)
+    net-imap (0.5.10)
       date
       net-protocol
     net-pop (0.1.2)
@@ -283,7 +283,7 @@ GEM
     tzinfo-data (1.2024.2)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -304,7 +304,7 @@ DEPENDENCIES
   listen
   pg (>= 0.18, < 2.0)
   puma (~> 6.4)
-  rails (~> 7.1.0)
+  rails (~> 7.1.5.2)
   rspec-rails
   sentry-rails (~> 5.13)
   sentry-ruby (~> 5.13)


### PR DESCRIPTION
Update rails version to 7.1.5.2 to fix dependabot alert: https://github.com/ministryofjustice/fb-user-datastore/security/dependabot/93