### PR TITLE
CDPTKAN-392: Dockerize fb-user-datastore

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 SUBMITTER_URL=http://localhost:3000
-SERVICE_TOKEN=service-token
+SERVICE_TOKEN_CACHE_ROOT_URL=http://localhost:3007
+MAX_IAT_SKEW_SECONDS="90"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ build: stop
 serve: build
 	$(DOCKER_COMPOSE) up -d db
 	./scripts/wait_for_db.sh db postgres
-	$(DOCKER_COMPOSE) up -d app
+	$(DOCKER_COMPOSE) up -d api
+
+setup: serve
 
 stop:
 	$(DOCKER_COMPOSE) down -v
@@ -25,8 +27,8 @@ stop:
 spec: build
 	$(DOCKER_COMPOSE) up -d db
 	./scripts/wait_for_db.sh db postgres
-	$(DOCKER_COMPOSE) up -d app
-	$(DOCKER_COMPOSE) run -e RAILS_ENV=test --rm app bundle exec rspec
+	$(DOCKER_COMPOSE) up -d api
+	$(DOCKER_COMPOSE) run -e RAILS_ENV=test --rm api bundle exec rspec
 
 build_and_push: install_build_dependencies login
 	docker build -t ${ECR_REPO_URL}:latest --build-arg BUNDLE_FLAGS="--without test development" -t ${ECR_REPO_URL}:${CIRCLE_SHA1} -f ./Dockerfile .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ networks:
 
 services:
   db:
+    container_name: user-datastore-db
     image: postgres:10.9-alpine
     restart: always
     environment:
@@ -18,6 +19,7 @@ services:
       - db-net
 
   api:
+    container_name: user-datastore-api
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
 version: '3.4'
 
+networks:
+  app-net:
+    name: fb-app-bridge-network
+  db-net:
+    name: fb-db-bridge-network
+
 services:
   db:
     image: postgres:10.9-alpine
@@ -7,21 +13,25 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
-      POSTGRES_DB: submitter_local
+      POSTGRES_DB: user_datastore_local
+    networks:
+      - db-net
 
-  app:
+  api:
     build:
       context: .
       dockerfile: ./Dockerfile
     environment:
-      DATABASE_URL: "postgres://postgres:password@db/submitter_local"
+      DATABASE_URL: "postgres://postgres:password@db/user_datastore_local"
       RAILS_ENV: development
       RAILS_SERVE_STATIC_FILES: "false"
       MAX_IAT_SKEW_SECONDS: "90"
       RAILS_LOG_TO_STDOUT: "true"
       SECRET_KEY_BASE: 'secret_key_base'
-    links:
+      SUBMITTER_URL: http://submitter-api:3000
+      SERVICE_TOKEN_CACHE_ROOT_URL: http://runner-service-token-cache-api:3000
+    depends_on:
       - db
-    ports:
-      - "3000:3000"
-
+    networks:
+      - app-net
+      - db-net


### PR DESCRIPTION
- Group containers into functional networks
  - app-net
  - db-net
- Rename Services to use the convention (app for Application Frontend (Web UI) and api for Backend API)
- Spin up the following services on make setup


  <img width="684" height="169" alt="Screenshot 2025-11-27 at 09 57 13" src="https://github.com/user-attachments/assets/4007740b-9930-4907-b091-1f9b38622a39" />

